### PR TITLE
Fix validations

### DIFF
--- a/src/containers/Contract.js
+++ b/src/containers/Contract.js
@@ -167,7 +167,12 @@ const Contract = (props) => {
             .required(t('NO_CITY'))
         }),
         is_housing: Yup.bool()
-          .oneOf([true, false], t('NO_IS_HOUSING')),
+          .oneOf([true, false], t('NO_IS_HOUSING'))
+          .test('CnaeNoHousing',
+            t('INVALID_CNAE_NO_HOUSING'),
+            function () {
+              return !(this.parent.is_housing === false && this.parent.cnae === CNAE_HOUSING)
+            }),
         cnae: Yup.string()
           .required(t('INVALID_SUPPLY_POINT_CNAE'))
           .min(3, t('INVALID_SUPPLY_POINT_CNAE'))

--- a/src/containers/Contract/PowerFare.js
+++ b/src/containers/Contract/PowerFare.js
@@ -38,7 +38,7 @@ const PowerInputs = (props) => {
       key={attr}
       id={attr}
       name={`contract.${attr}`}
-      label={t('QUINA_POTENCIA_TENS_CONTRACTADA')}
+      label={ !values?.contract?.has_service ? t('POTENCIA_A_CONTRACTAR_CONTRACTACIO') : t('QUINA_POTENCIA_TENS_CONTRACTADA') }
       InputProps={{
         autoComplete: 'off',
         endAdornment: <InputAdornment position="end">kW</InputAdornment>,
@@ -51,7 +51,7 @@ const PowerInputs = (props) => {
       variant="outlined"
       margin="normal"
       error={(errors?.contract && errors?.contract[attr] && touched?.contract && touched?.contract[attr])}
-      helperText={(touched?.contract && touched?.contract[attr] && errors.contract && errors?.contract[attr]) || t('HELP_POPOVER_POWER')}
+      helperText={(touched?.contract && touched?.contract[attr] && errors.contract && errors?.contract[attr]) || (values?.contract?.has_service && t('HELP_POPOVER_POWER'))}
     />)
   })
 }

--- a/src/containers/Contract/SupplyPoint.js
+++ b/src/containers/Contract/SupplyPoint.js
@@ -210,9 +210,14 @@ const SupplyPoint = (props) => {
             />
           </Grid>
           <Grid item xs={12} className={classes.noPaddingTop}>
-            <Typography>
-              {t('ADJUNTAR_ULTIMA_FACTURA')}
-            </Typography>
+            { values?.contract?.has_service
+              ? <Typography>
+                {t('ADJUNTAR_ULTIMA_FACTURA')}
+              </Typography>
+              : <Typography>
+                {t("ADJUNTAR_DOCUMENTACIO")}
+              </Typography>
+            }
             <Box mt={1} mb={1}>
               <Uploader
                 fieldError={errors.supply_point?.attachments && touched.supply_point?.attachments && errors.supply_point?.attachments}

--- a/src/containers/Member.js
+++ b/src/containers/Member.js
@@ -80,7 +80,9 @@ const Member = (props) => {
   const validationSchemas = [
     Yup.object().shape({
       member: Yup.object().shape({
-        vat: Yup.string().required(t('FILL_NIF')),
+        vat: Yup.string()
+          .required(t('FILL_NIF'))
+          .matches(/(^[A-GI-Z0-9])/, t('FILL_NIF')),
         vatvalid: Yup.bool().required(t('FILL_NIF'))
           .oneOf([true], t('FILL_NIF'))
       })

--- a/src/containers/Member.js
+++ b/src/containers/Member.js
@@ -82,7 +82,7 @@ const Member = (props) => {
       member: Yup.object().shape({
         vat: Yup.string()
           .required(t('FILL_NIF'))
-          .matches(/(^[A-GI-Z0-9])/, t('FILL_NIF')),
+          .matches(/(^[A-GI-Z0-9])/, t('CIF_COMMUNITY_OWNERS')),
         vatvalid: Yup.bool().required(t('FILL_NIF'))
           .oneOf([true], t('FILL_NIF'))
       })

--- a/src/i18n/locale-ca.json
+++ b/src/i18n/locale-ca.json
@@ -83,6 +83,7 @@
     "VAT_LABEL": "Número d'identificació fiscal (NIF)",
     "VAT_HELP": "I si no disposo d'un NIF?",
     "NO_VAT_HELP": "Si no disposes de NIE i tens passaport, ens pots enviar un correu a <a target=\"_blank\" href=\"mailto:modifica@somenergia.coop\">modifica@somenergia.coop</a> amb les dades del punt de subministrament que vols canviar (número de contracte i CUPS), les dades de la nova persona titular (nom, cognoms, passaport adjunt, correu electrònic i telèfon de contacte) i dades IBAN de pagament.",
+    "CIF_COMMUNITY_OWNERS": "Lamentablement, per llei, les comunitats veïnals no poden fer-se sòcies de cooperatives. Us convidem a que sigui un membre de la comunitat veïnal, o bé la persona administradora de finques, qui es faci sòcia de Som Energia. Per a més informació, podeu consultar el Centre d’Ajuda.",
     "CUPS_TITLE": "Identifica el punt de subministrament",
     "FILL_CUPS": "Indica el <b>codi CUPS</b> (codi universal de punt de subministrament):",
     "CUPS_LABEL": "CUPS",

--- a/src/i18n/locale-ca.json
+++ b/src/i18n/locale-ca.json
@@ -265,6 +265,7 @@
     "INVALID_SUPPLY_POINT_CNAE": "No has especificat un <b>codi CNAE</b> vàlid pel punt de subministrament",
     "INVALID_CNAE_NO_HOUSING": "El punt de subministrament no és un habitatge, el CNAE no pot ser 9820",
     "ADJUNTAR_ULTIMA_FACTURA": "Adjuntar última factura elèctrica (PDF o JPG)",
+    "ADJUNTAR_DOCUMENTACIO": "Adjuntar la documentació per l'alta de subministrament (PDF o JPG) - 10Mb màxim",
 
     "TARIFA_I_POTENCIA": "Tarifa i potència",
     "HELP_TARIFA_CANVI_COMERCIALITZADORA": "Per evitar problemes de tramitació, poseu <b>la mateixa tarifa i potència que apareix a la factura actual</b>. Ens podreu sol·licitar canvis de tarifa o potència una vegada estigui el contracte activat amb nosaltres.",

--- a/src/i18n/locale-es.json
+++ b/src/i18n/locale-es.json
@@ -281,6 +281,7 @@
   "INVALID_SUPPLY_POINT_CNAE": "No has especificado un código CNAE válido",
   "INVALID_CNAE_NO_HOUSING": "El punto de suministro no es una vivienda, el CNAE no puede ser 9820",
   "ADJUNTAR_ULTIMA_FACTURA": "Adjuntar la última factura eléctrica (opcional)",
+  "ADJUNTAR_DOCUMENTACIO": "Adjuntar la documentación para el alta de suministro (PDF o JPG) - 10Mb máximo",
 
   "TARIFA_I_POTENCIA": "Tarifa y potencia",
   "HELP_TARIFA_CANVI_COMERCIALITZADORA": "Para evitar problemas de tramitación, ponga <b>la misma tarifa y potencia que aparece en la factura actual</b>. Podrá solicitar el cambio de tarifa o potencia una vez esté el contrato activado con nosotros.",

--- a/src/i18n/locale-es.json
+++ b/src/i18n/locale-es.json
@@ -85,6 +85,7 @@
   "VAT_LABEL": "Número de Identificación Fiscal (NIF)",
   "VAT_HELP": "¿Y si no dispongo de NIF?",
   "NO_VAT_HELP": "Si no dispones de NIE y tienes pasaporte, puedes enviarnos un correo a <a target=\"_blank\" href=\"mailto:modifica@somenergia.coop\">modifica@somenergia.coop</a> con los datos del punto de suministro que quieres cambiar (número de contrato y CUPS) y los datos de la nueva persona titular (nombre, apellidos, pasaporte adjunto, correo electrónico y teléfono de contacto) y datos IBAN de pago.",
+  "CIF_COMMUNITY_OWNERS": "Lamentablemente, por ley, las comunidades de vecinos no pueden hacerse socias de cooperativas. Os invitamos a que sea un miembro de la comunidad de vecinos, o bien la persona administradora de fincas, quien se haga socia de Som Energia. Para más información, podéis consultar el Centro de Ayuda.",
 
   "CUPS_TITLE": "Identifica el punto de suministro",
   "FILL_CUPS": "Indica el código CUPS (Código Universal de Punto de Suministro):",


### PR DESCRIPTION
Some validation fixes:
- CNAE validation: "is housing" check shows error if the specified CANE "is housing".
- Member VAT can not be from a community of owners.
- Changed text when CUPS has no service:
  - Ask for documentation instead of the last invoice.
  - Ask for the power you want instead of the power you have.