### PR TITLE
remove validateForm from choosers handler

### DIFF
--- a/cypress/fixtures/contract.json
+++ b/cypress/fixtures/contract.json
@@ -59,7 +59,7 @@
   },
   "selfConsumption": {
     "have_installation": true,
-    "cau": "ES0353501028615353EEA0001",
+    "cau": "ES0353501028615353EEA000",
     "collective_installation": true,
     "installation_power": "3.5",
     "installation_type": "01",

--- a/src/containers/Contract/SelfConsumptionDetails.js
+++ b/src/containers/Contract/SelfConsumptionDetails.js
@@ -34,12 +34,10 @@ const SelfConsumptionDetails = (props) => {
 
   const handleCollectiveInstallation = ({ option }) => {
     setFieldValue('self_consumption.collective_installation', option)
-    validateForm()
   }
 
   const handleAuxiliaryService = ({ option }) => {
     setFieldValue('self_consumption.aux_services', option)
-    validateForm()
   }
 
   const handleChangeSelect = (event) => {

--- a/src/containers/HolderChange/VoluntaryCent.js
+++ b/src/containers/HolderChange/VoluntaryCent.js
@@ -12,7 +12,6 @@ function VoluntaryCent(props) {
 
   const handleChange = ({ option }) => {
     props.setFieldValue('payment.voluntary_cent', option)
-    //props.validateForm()
   }
 
   return (


### PR DESCRIPTION
### Problem:
On `SelfConsumptionDetails` screen in `Contract` form, choosers didn't work correctly. When we select an option and deselect it, the "Next" button gets enabled.

-------

### Solution:
* We removed `validationForm` from choosers handlers
* *Bonus: fixed CAU field in order to pass cypress tests*

------

### TODO:
- [ ] Check if attachments are required on selfconsumption screen in contract form