### PR TITLE
fix language use in Success container

### DIFF
--- a/src/containers/Failure.js
+++ b/src/containers/Failure.js
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useParams } from 'react-router-dom'
 import { makeStyles } from '@material-ui/core/styles'
 
 import Avatar from '@material-ui/core/Avatar'
@@ -48,6 +49,7 @@ const useStyles = makeStyles((theme) => ({
 }))
 
 function Failure(props) {
+  const { language } = useParams()
   const { t, i18n } = useTranslation()
   const classes = useStyles()
   const {
@@ -57,9 +59,8 @@ function Failure(props) {
   } = props
 
   useEffect(() => {
-    const language = props?.match?.params?.language
-    language && i18n.changeLanguage(language)
-  }, [props?.match?.params?.language, i18n])
+    i18n.changeLanguage(language)
+  }, [language, i18n])
 
   return (
     <>

--- a/src/containers/Success.js
+++ b/src/containers/Success.js
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useParams } from 'react-router-dom'
 import { makeStyles } from '@material-ui/core/styles'
 
 import Avatar from '@material-ui/core/Avatar'
@@ -50,12 +51,12 @@ const useStyles = makeStyles((theme) => ({
 const Success = (props) => {
   const { result, description, title, showHeader = true } = props
   const classes = useStyles()
+  const { language } = useParams()
   const { t, i18n } = useTranslation()
 
   useEffect(() => {
-    const language = props?.match?.params?.language
-    language && i18n.changeLanguage(language)
-  }, [props?.match?.params?.language, i18n])
+    i18n.changeLanguage(language)
+  }, [language, i18n])
 
   return (
     <>


### PR DESCRIPTION
## Case
When we try to pay an unpaid invoice from the OV, the language of the title (SUCCESS_TEXT) on Success/Failure screen, wasn't changing. :face_with_spiral_eyes: 

## Proposed solution
The language of i18n is changed like it's done on Tariff container. :thinking: 

------------

The language was not set because `props?.match?.params?.language` was `undefined`.
I'm not sure if that change could have more consequences. Can we check it?

Thanks!! :dango: 