### PR TITLE
Removed max_power validation for 30TD

### DIFF
--- a/src/components/PowerInputs.js
+++ b/src/components/PowerInputs.js
@@ -17,12 +17,9 @@ const handleChangePower = (
   let result = match[0].replace(',', '.')
   result = result.replace("'", '.')
 
-  result =
-    !moreThan15Kw && result <= 15
-      ? result
-      : moreThan15Kw && result < 450
-      ? result
-      : result.slice(0, -1)
+  if (!moreThan15Kw && result > 15){
+    result = result.slice(0, -1)
+  }
 
   setFieldValue(event.target.name, result)
 }

--- a/src/containers/ModifyContract/Params.js
+++ b/src/containers/ModifyContract/Params.js
@@ -215,18 +215,6 @@ const ModifyParams = ({ nextStep, prevStep, handleStepChanges, params }) => {
             t
           )
         }
-      })
-      .test({
-        name: 'maxPowerValue',
-        test: function () {
-          return testPowerForPeriods(
-            rates,
-            this.parent,
-            'max_power',
-            this.createError,
-            t
-          )
-        }
       }),
     power4: Yup.number()
       .test('required', t('NO_POWER_CHOSEN_PX'), function () {
@@ -247,18 +235,6 @@ const ModifyParams = ({ nextStep, prevStep, handleStepChanges, params }) => {
             rates,
             this.parent,
             'min_power',
-            this.createError,
-            t
-          )
-        }
-      })
-      .test({
-        name: 'maxPowerValue',
-        test: function () {
-          return testPowerForPeriods(
-            rates,
-            this.parent,
-            'max_power',
             this.createError,
             t
           )
@@ -287,18 +263,6 @@ const ModifyParams = ({ nextStep, prevStep, handleStepChanges, params }) => {
             t
           )
         }
-      })
-      .test({
-        name: 'maxPowerValue',
-        test: function () {
-          return testPowerForPeriods(
-            rates,
-            this.parent,
-            'max_power',
-            this.createError,
-            t
-          )
-        }
       }),
     power6: Yup.number()
       .test('required', t('NO_POWER_CHOSEN_PX'), function () {
@@ -319,18 +283,6 @@ const ModifyParams = ({ nextStep, prevStep, handleStepChanges, params }) => {
             rates,
             this.parent,
             'min_power',
-            this.createError,
-            t
-          )
-        }
-      })
-      .test({
-        name: 'maxPowerValue',
-        test: function () {
-          return testPowerForPeriods(
-            rates,
-            this.parent,
-            'max_power',
             this.createError,
             t
           )

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -441,12 +441,21 @@ export const testPowerForPeriods = (
 ) => {
   const rate = values?.rate || values?.tariff
   let valids = 0
+  let inLimit = false
+
   if (rates[rate] === undefined) return true
+
   for (let i = 1; i <= rates[rate]?.num_power_periods; i++) {
     const attr = i === 1 ? 'power' : `power${i}`
-    const inLimit = limit.match('min')
-      ? values[attr] >= rates[rate][limit]?.power
-      : values[attr] <= rates[rate][limit]?.power
+
+    if (limit.match('min')) {
+     inLimit = values[attr] >= rates[rate][limit]?.power
+    } else {
+      inLimit = rate == '2.0TD'
+        ? values[attr] <= rates[rate][limit]?.power
+        : true
+    }
+
     inLimit && valids++
     values[attr] === undefined && valids++
   }


### PR DESCRIPTION
30TD tariffs haven't a maximum power limit, so validate against a predefined max value is no more required.

This pull request removes that validation for 30TD contracts.