### PR TITLE
Don't make video for each run, please

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -2,5 +2,7 @@
   "projectId": "6y5vbm",
   "baseUrl": "http://localhost:3000",
   "viewportWidth": 1200,
-  "viewportHeight": 960
+  "viewportHeight": 960,
+  "video": false,
+  "videoUploadOnPasses": false
 }


### PR DESCRIPTION
## Change
### Previous behavior
- Make video for each test
- Time example:
![image](https://user-images.githubusercontent.com/36006206/176593390-6a48d691-4308-4ee9-bde3-7465307a6e7a.png)

### Current behavior
- Only if test fail, cypress will take a screenshot of the page of error
- Time example:
![image](https://user-images.githubusercontent.com/36006206/176593360-92032cf3-62cd-4946-b746-eac29324b951.png)
