### PR TITLE
Holder change due to company merge requires documentation (Front End)

### DIFF
--- a/src/containers/HolderChange.js
+++ b/src/containers/HolderChange.js
@@ -233,6 +233,15 @@ function HolderChange(props) {
                 .required(t('ELECTRODEP_ATTACH_REQUIRED'))
             })
           })
+          .when('reason_merge', {
+            is: true,
+            then: Yup.object().shape({
+              merge: Yup.array()
+                .min(1, t('ELECTRODEP_ATTACH_REQUIRED'))
+                .max(1, t('ELECTRODEP_ATTACH_REQUIRED'))
+                .required(t('ELECTRODEP_ATTACH_REQUIRED')),
+            })
+          })
       })
     }),
     Yup.object().shape({

--- a/src/containers/HolderChange/SpecialCases.js
+++ b/src/containers/HolderChange/SpecialCases.js
@@ -116,6 +116,7 @@ const SpecialCases = (props) => {
         reason_electrodep: false,
         attachments: {
           death: [],
+          merge: [],
           medical: [],
           resident: []
         }
@@ -208,6 +209,29 @@ const SpecialCases = (props) => {
                   classes.chooserItemSelected
               )}
             />
+            {values.especial_cases?.reason_merge && (
+              <>
+                <Typography className={classes.attachmentTitle}>
+                  {t('CERT_ATTACH_MERGE')}
+                </Typography>
+                <Box mt={1} mb={2}>
+                  <Uploader
+                    fieldError={
+                      errors.attachments &&
+                      touched.attachments &&
+                      errors.attachments
+                    }
+                    callbackFn={(attachments) =>
+                      setFieldValue(
+                        'especial_cases.attachments.merge',
+                        attachments
+                      )
+                    }
+                    values={values.especial_cases.attachments?.merge}
+                  />
+                </Box>
+              </>
+            )}
             <FormControlLabel
               disabled={values.especial_cases?.reason_merge}
               control={

--- a/src/i18n/locale-ca.json
+++ b/src/i18n/locale-ca.json
@@ -215,6 +215,7 @@
     "SPECIAL_CASES_REASON_MERGE": "El canvi de titular es fa per una fusió d'empreses",
     "SPECIAL_CASES_REASON_ELECTRODEP": "Al domicili viu una persona electrodependent",
     "CERT_ATTACH_DEATH": "Certificat de defunció",
+    "CERT_ATTACH_MERGE": "Certificat de fusió",
     "ELECTRODEP_ATTACH_MEDICAL": "Certificat mèdic d'electrodependència",
     "ELECTRODEP_ATTACH_RESIDENT": "Certificat d'empadronament",
     "ELECTRODEP_ATTACH_REQUIRED": "Cal adjuntar els certificats demanats",

--- a/src/i18n/locale-es.json
+++ b/src/i18n/locale-es.json
@@ -215,6 +215,7 @@
     "SPECIAL_CASES_REASON_MERGE": "El cambio se hace por una fusión de empresas acreditada",
     "SPECIAL_CASES_REASON_ELECTRODEP": "En el domicilio vive una persona electrodependiente",
     "CERT_ATTACH_DEATH": "Certificado de defunción",
+    "CERT_ATTACH_MERGE": "Certificado de fusión",
     "ELECTRODEP_ATTACH_MEDICAL": "Certificado médico de electrodependencia",
     "ELECTRODEP_ATTACH_RESIDENT": "Certificado de empadronamiento",
     "ELECTRODEP_ATTACH_REQUIRED": "Tienes que adjuntar los certificados solicitados",

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -239,6 +239,11 @@ export const normalizeHolderChange = (contract) => {
         normalContract.especial_cases.attachments.resident =
           normalContract?.especial_cases?.attachments?.resident[0]
       }
+
+      if (normalContract?.especial_cases?.attachments?.merge) {
+        normalContract.especial_cases.attachments.merge =
+          normalContract?.especial_cases?.attachments?.merge[0]
+      }
     }
   }
   return normalContract


### PR DESCRIPTION
Holder changes because a company merge now require attachments.

The PR adds the attachment field, requires it in case of merge, and sends it to the backend.
