### PR TITLE
Adapt response to new funtion get_tariff_prices

### DIFF
--- a/src/containers/Contract/Review.jsx
+++ b/src/containers/Contract/Review.jsx
@@ -58,7 +58,7 @@ const Review = (props) => {
       city_id: values.supply_point.city.id
     })
       .then((response) => {
-        const tariffPrices = response?.data
+        const tariffPrices = response?.data['current']
         setPrices(tariffPrices)
         setLoading(false)
       })
@@ -181,7 +181,7 @@ const Review = (props) => {
               }
             }}>
             <span key={`${name}`}>
-              {`${concept[key]?.value} ${concept[key]?.uom}`}
+              {`${concept[key]?.value} ${concept[key]?.unit}`}
             </span>
           </Box>
         )
@@ -207,7 +207,7 @@ const Review = (props) => {
         {concept ? (
           keys.map((key, index) => (
             <span key={`${name}:${key}`}>
-              {`${labels[index]}: ${concept[key]?.value} ${concept[key]?.uom}`}
+              {`${labels[index]}: ${concept[key]?.value} ${concept[key]?.unit}`}
             </span>
           ))
         ) : (
@@ -495,28 +495,28 @@ const Review = (props) => {
                 <Grid item xs={12} sm={6}>
                   <ReviewField
                     label={t('TERME_ENERGIA')}
-                    value={<Prices concept={prices?.te} name="te" />}
+                    value={<Prices concept={prices?.energia} name="te" />}
                     multipleValues={true}
                   />
                 </Grid>
                 <Grid item xs={12} sm={6}>
                   <ReviewField
                     label={t('GENERATION')}
-                    value={<Prices concept={prices?.gkwh} name="gkwh" />}
+                    value={<Prices concept={prices?.generation_kWh} name="gkwh" />}
                     multipleValues={true}
                   />
                 </Grid>
                 <Grid item xs={12} sm={6}>
                   <ReviewField
                     label={t('TERME_POTENCIA')}
-                    value={<Prices concept={prices?.tp} name="tp" />}
+                    value={<Prices concept={prices?.potencia} name="tp" />}
                     multipleValues={true}
                   />
                 </Grid>
                 <Grid item xs={12} sm={6}>
                   <ReviewField
                     label={t('AUTOCONSUM')}
-                    value={<Prices concept={prices?.ac} name="ac" />}
+                    value={<Prices concept={prices?.energia_autoconsumida} name="ac" />}
                     multipleValues={true}
                   />
                 </Grid>
@@ -524,7 +524,7 @@ const Review = (props) => {
                   <Grid item xs={12} sm={6}>
                     <ReviewField
                       label={t('BO_SOCIAL')}
-                      value={`${prices?.bo_social?.value} ${prices?.bo_social?.uom}`}
+                      value={`${prices?.bo_social?.value} ${prices?.bo_social?.unit}`}
                       multipleValues={true}
                     />
                   </Grid>

--- a/src/containers/Tariff.jsx
+++ b/src/containers/Tariff.jsx
@@ -16,7 +16,7 @@ const Tariff = (props) => {
     i18n.changeLanguage(language)
   }, [language, i18n])
 
-  useEffect(() => {
+ useEffect(() => {
     const CITY_TAX_21 = 20
     const CITY_TAX_10 = 37
 
@@ -26,7 +26,7 @@ const Tariff = (props) => {
       city_id: taxType === 21 ? CITY_TAX_21 : CITY_TAX_10
     })
       .then((response) => {
-        const tariffPrices = response?.data
+        const tariffPrices = response?.data['current']
         setPrices(tariffPrices)
         setLoading(false)
       })
@@ -81,13 +81,13 @@ const Tariff = (props) => {
           <div className="tp">
             <h4>{t('TERME_POTENCIA')}</h4>
             <p className="titol">
-              {prices?.tp &&
-                Object.keys(prices?.tp)
+              {prices?.potencia &&
+                Object.keys(prices?.potencia)
                   .reverse()
                   .map((period) => (
                     <span key={period}>
                       {powerPeriodNames[`${tariff}_${period}`] ?? period}{' '}
-                      {prices.tp[period]?.value} {prices.tp[period]?.uom}
+                      {prices.potencia[period]?.value} {prices.potencia[period]?.unit}
                       <br />
                     </span>
                   ))}
@@ -96,13 +96,13 @@ const Tariff = (props) => {
           <div className="te">
             <h4>{t('TERME_ENERGIA')}</h4>
             <p className="titol">
-              {prices?.te &&
-                Object.keys(prices?.te)
+              {prices?.energia &&
+                Object.keys(prices?.energia)
                   .reverse()
                   .map((period) => (
                     <span key={period}>
                       {energyPeriodNames[`${tariff}_${period}`] ?? period}{' '}
-                      {prices.te[period]?.value} {prices.te[period]?.uom}
+                      {prices.energia[period]?.value} {prices.energia[period]?.unit}
                       <br />
                     </span>
                   ))}
@@ -116,13 +116,13 @@ const Tariff = (props) => {
                 })
               }}></h4>
             <p className="titol">
-              {prices?.gkwh &&
-                Object.keys(prices?.gkwh)
+              {prices?.generation_kWh &&
+                Object.keys(prices?.generation_kWh)
                   .reverse()
                   .map((period) => (
                     <span key={period}>
                       {energyPeriodNames[`${tariff}_${period}`] ?? period}{' '}
-                      {prices.gkwh[period]?.value} {prices.gkwh[period]?.uom}
+                      {prices.generation_kWh[period]?.value} {prices.generation_kWh[period]?.unit}
                       <br />
                     </span>
                   ))}
@@ -136,12 +136,12 @@ const Tariff = (props) => {
                 })
               }}></h4>
             <p className="titol">
-              {prices?.ac &&
-                Object.keys(prices?.ac)
+              {prices?.energia_autoconsumida &&
+                Object.keys(prices?.energia_autoconsumida)
                   .reverse()
                   .map((period) => (
                     <span key={period}>
-                      {prices.ac[period]?.value} {prices.ac[period]?.uom}
+                      {prices.energia_autoconsumida[period]?.value} {prices.energia_autoconsumida[period]?.unit}
                       <br />
                     </span>
                   ))}


### PR DESCRIPTION
Method get_tariff_prices returns a dictionary with 'current' and 'history' prices. Only 'current' key is considered  from the response.
Also keys of prices had changed:
- 'tp' : 'potencia'
- 'te': 'energia'
- 'gkwh': 'generation_kWh'
- 'ac': 'energia-autoconsumida

Now 'energia-autocumsumida' returns one value for each period.