### PR TITLE
Smoother error messages for expected contract condition on tariff change 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+- Indexed: Errors on contract state are not fatal just shown
+  in the first info page, not with the dead firefly
+
 ## 1.9.1 2023-09-04
 
 - Fix general conditions for holderchange form
@@ -10,7 +15,7 @@
 
 - Added: Generation kwh. the way for partners
 
-## 1.8.2 2023-08-23 
+## 1.8.2 2023-08-23
 
 - Fix: The way to sort the list of assignments, when there are low contracts
 - Fix: Indexed test with the new condition IsIndexedPilotOngoing
@@ -22,7 +27,7 @@
 ## 1.8.0 2023-07-18
 
 - Added the new investments table
-- Added the new assignments table 
+- Added the new assignments table
 - New Action: Partners can modify the priority of their assignments using drag and drop
 
 ## 1.7.7 2023-07-17

--- a/src/components/DropDownMenu.js
+++ b/src/components/DropDownMenu.js
@@ -68,7 +68,7 @@ export default function DropDownMenu({ title, sections = [] }) {
     <div>
       {title ? (
         <Grid container item className={classes.menuTitle}>
-          <Typography style={{fontSize:'16px'}} variant="subtitle">{title}</Typography>
+          <Typography style={{fontSize:'16px'}} variant="subtitle1">{title}</Typography>
         </Grid>
       ) : null}
       {sections.map((element, index) => {

--- a/src/containers/Indexed.js
+++ b/src/containers/Indexed.js
@@ -33,7 +33,7 @@ import Grid from '@material-ui/core/Grid'
 import DropDownMenu from '../components/DropDownMenu'
 import Loading from 'components/Loading'
 import IndexedInfo from './Indexed/IndexedInfo'
-import IndexedError from './Indexed/IndexedError'
+import indexedErrorText from './Indexed/IndexedError'
 import { checkIsTariff20, checkIsTariff30 } from '../services/utils'
 import { checkIsTariffIndexed } from '../services/utils'
 
@@ -280,7 +280,7 @@ const Indexada = (props) => {
     : t('INDEXED_IMPORTANT_INFO_BODY_30', translatedUrls)
 
   const introBody = error
-    ? IndexedError(t, error?.code, error?.data)
+    ? indexedErrorText(t, error?.code, error?.data)
     : isTariffIndexed
     ? t('PERIODS_INTRO_BODY', translatedUrls)
     : t('INDEXED_INTRO_BODY', translatedUrls)

--- a/src/containers/Indexed.js
+++ b/src/containers/Indexed.js
@@ -230,237 +230,231 @@ const Indexada = (props) => {
     )
   }
 
+  if (loadingTariff) return <Loading />
+
   return (
     <>
-      {loadingTariff ? (
-        <Loading />
-      ) : (
-        <GlobalHotKeys handlers={handlers} keyMap={keyMap}>
-          {checkEnabled && !hasTargetTariff ? (
-            <Failure error={error} showHeader={false} />
-          ) : (
-            <MuiPickersUtilsProvider utils={DayjsUtils}>
-              <Grid container justifyContent="space-between">
-                <Grid item xs={8}>
-                  <Formik
-                    onSubmit={() => {}}
-                    enableReinitialize
-                    initialValues={initialValues}
-                    validationSchema={validationSchemas[activeStep]}
-                    validateOnMount={true}>
-                    {(formikProps) => (
-                      <>
-                        <Form
-                          id="cancelForm"
-                          method="POST"
-                          className={classes.root}
-                          noValidate
-                          autoComplete="off">
-                          <Container maxWidth="lg" disableGutters={true}>
-                            {!completed && (
-                              <>
-                                {activeStep !== 2 ? (
-                                  <IndexedContractDetails
-                                    {...formikProps.values}
-                                    data={contractJSON}
-                                    targetTariff={hasTargetTariff}
-                                    isTariff20={isTariff20}
-                                    isTariffIndexed={isTariffIndexed}
-                                  />
-                                ) : null}
+      <GlobalHotKeys handlers={handlers} keyMap={keyMap}>
+        {checkEnabled && !hasTargetTariff ? (
+          <Failure error={error} showHeader={false} />
+        ) : (
+          <MuiPickersUtilsProvider utils={DayjsUtils}>
+            <Grid container justifyContent="space-between">
+              <Grid item xs={8}>
+                <Formik
+                  onSubmit={() => {}}
+                  enableReinitialize
+                  initialValues={initialValues}
+                  validationSchema={validationSchemas[activeStep]}
+                  validateOnMount={true}>
+                  {(formikProps) => (
+                    <>
+                      <Form
+                        id="cancelForm"
+                        method="POST"
+                        className={classes.root}
+                        noValidate
+                        autoComplete="off">
+                        <Container maxWidth="lg" disableGutters={true}>
+                          {!completed && (
+                            <>
+                              {activeStep !== 2 ? (
+                                <IndexedContractDetails
+                                  {...formikProps.values}
+                                  data={contractJSON}
+                                  targetTariff={hasTargetTariff}
+                                  isTariff20={isTariff20}
+                                  isTariffIndexed={isTariffIndexed}
+                                />
+                              ) : null}
 
-                                {activeStep === 0 ? (
-                                  <IndexedInfo
-                                    isTariff20={isTariff20}
-                                    isTariff30={isTariff30}
-                                    isTariffIndexed={isTariffIndexed}
-                                    desc={t(
-                                      isTariffIndexed
-                                        ? 'PERIODS_INTRO_BODY'
-                                        : 'INDEXED_INTRO_BODY',
-                                      {
-                                        url_tariff_index_characteristics: t(
+                              {activeStep === 0 ? (
+                                <IndexedInfo
+                                  isTariff20={isTariff20}
+                                  isTariff30={isTariff30}
+                                  isTariffIndexed={isTariffIndexed}
+                                  desc={t(
+                                    isTariffIndexed
+                                      ? 'PERIODS_INTRO_BODY'
+                                      : 'INDEXED_INTRO_BODY',
+                                    {
+                                      url_tariff_index_characteristics: t(
+                                        isTariff20
+                                          ? 'TARIFF_CHARACTERISTICS_INDEX_20_URL'
+                                          : isTariff30
+                                          ? 'TARIFF_CHARACTERISTICS_INDEX_30_URL'
+                                          : 'TARIFF_CHARACTERISTICS_INDEX_6_URL'
+                                      ),
+                                      url_general_conditions: t(
+                                        'GENERAL_CONDITIONS_URL'
+                                      ),
+                                      url_specific_conditions: t(
+                                        'INDEXED_SPECIFIC_CONDITIONS_URL'
+                                      ),
+                                      url_tariff_characteristics: t(
+                                        isTariff20
+                                          ? 'TARIFF_CHARACTERISTICS_20_URL'
+                                          : isTariff30
+                                          ? 'TARIFF_CHARACTERISTICS_30_URL'
+                                          : 'TARIFF_CHARACTERISTICS_6_URL'
+                                      )
+                                    }
+                                  )}
+                                  {...formikProps}
+                                />
+                              ) : null}
+                              {activeStep === 1 ? (
+                                <IndexedInfo
+                                  isTariff20={isTariff20}
+                                  isTariff30={isTariff30}
+                                  isTariffIndexed={isTariffIndexed}
+                                  title={t('INDEXED_INTRO_TITLE')}
+                                  desc={
+                                    isTariffIndexed
+                                      ? t(
                                           isTariff20
-                                            ? 'TARIFF_CHARACTERISTICS_INDEX_20_URL'
+                                            ? 'PERIODS_IMPORTANT_INFO_BODY'
                                             : isTariff30
-                                            ? 'TARIFF_CHARACTERISTICS_INDEX_30_URL'
-                                            : 'TARIFF_CHARACTERISTICS_INDEX_6_URL'
-                                        ),
-                                        url_general_conditions: t(
-                                          'GENERAL_CONDITIONS_URL'
-                                        ),
-                                        url_specific_conditions: t(
-                                          'INDEXED_SPECIFIC_CONDITIONS_URL'
-                                        ),
-                                        url_tariff_characteristics: t(
-                                          isTariff20
-                                            ? 'TARIFF_CHARACTERISTICS_20_URL'
-                                            : isTariff30
-                                            ? 'TARIFF_CHARACTERISTICS_30_URL'
-                                            : 'TARIFF_CHARACTERISTICS_6_URL'
+                                            ? 'PERIODS_IMPORTANT_INFO_BODY_30'
+                                            : 'PERIODS_IMPORTANT_INFO_BODY_6',
+                                          {
+                                            url_tariff_characteristics: t(
+                                              isTariff20
+                                                ? 'TARIFF_CHARACTERISTICS_20_URL'
+                                                : isTariff30
+                                                ? 'TARIFF_CHARACTERISTICS_30_URL'
+                                                : 'TARIFF_CHARACTERISTICS_6_URL'
+                                            ),
+                                            url_tariff_web: t(
+                                              isTariff20
+                                                ? 'TARIFF_WEB_URL'
+                                                : isTariff30
+                                                ? 'TARIFF_WEB_30_URL'
+                                                : 'TARIFF_WEB_6_URL'
+                                            )
+                                          }
                                         )
-                                      }
-                                    )}
-                                    {...formikProps}
-                                  />
-                                ) : null}
-                                {activeStep === 1 ? (
-                                  <IndexedInfo
-                                    isTariff20={isTariff20}
-                                    isTariff30={isTariff30}
-                                    isTariffIndexed={isTariffIndexed}
-                                    title={t('INDEXED_INTRO_TITLE')}
-                                    desc={
-                                      isTariffIndexed
-                                        ? t(
-                                            isTariff20
-                                              ? 'PERIODS_IMPORTANT_INFO_BODY'
-                                              : isTariff30
-                                              ? 'PERIODS_IMPORTANT_INFO_BODY_30'
-                                              : 'PERIODS_IMPORTANT_INFO_BODY_6',
-                                            {
-                                              url_tariff_characteristics: t(
-                                                isTariff20
-                                                  ? 'TARIFF_CHARACTERISTICS_20_URL'
-                                                  : isTariff30
-                                                  ? 'TARIFF_CHARACTERISTICS_30_URL'
-                                                  : 'TARIFF_CHARACTERISTICS_6_URL'
-                                              ),
-                                              url_tariff_web: t(
-                                                isTariff20
-                                                  ? 'TARIFF_WEB_URL'
-                                                  : isTariff30
-                                                  ? 'TARIFF_WEB_30_URL'
-                                                  : 'TARIFF_WEB_6_URL'
-                                              )
-                                            }
-                                          )
-                                        : t(
-                                            isTariff20
-                                              ? 'INDEXED_IMPORTANT_INFO_BODY'
-                                              : 'INDEXED_IMPORTANT_INFO_BODY_30',
-                                            {
-                                              url_indexada_help: t(
-                                                'TARIFF_INDEXED_HELP_URL'
-                                              )
-                                            }
-                                          )
-                                    }
-                                    {...formikProps}
-                                  />
-                                ) : null}
-                                {activeStep === 2 ? (
-                                  <IndexedReview
-                                    isTariff20={isTariff20}
-                                    isTariffIndexed={isTariffIndexed}
-                                    isIndexedPilotOngoing={
-                                      isIndexedPilotOngoing
-                                    }
-                                    targetTariff={hasTargetTariff}
-                                    contractValues={contractJSON}
-                                    {...formikProps}
-                                  />
-                                ) : null}
-                                <Box mx={0} mt={2} mb={3}>
-                                  <div className={classes.actionsContainer}>
-                                    {result?.contract_number === undefined && (
-                                      <Button
-                                        data-cy="prev"
-                                        className={classes.button}
-                                        startIcon={<ArrowBackIosIcon />}
-                                        disabled={activeStep === 0 || loading}
-                                        onClick={() => prevStep(formikProps)}>
-                                        {t('PAS_ANTERIOR')}
-                                      </Button>
-                                    )}
-                                    {activeStep < MAX_STEP_NUMBER - 1 ? (
+                                      : t(
+                                          isTariff20
+                                            ? 'INDEXED_IMPORTANT_INFO_BODY'
+                                            : 'INDEXED_IMPORTANT_INFO_BODY_30',
+                                          {
+                                            url_indexada_help: t(
+                                              'TARIFF_INDEXED_HELP_URL'
+                                            )
+                                          }
+                                        )
+                                  }
+                                  {...formikProps}
+                                />
+                              ) : null}
+                              {activeStep === 2 ? (
+                                <IndexedReview
+                                  isTariff20={isTariff20}
+                                  isTariffIndexed={isTariffIndexed}
+                                  isIndexedPilotOngoing={isIndexedPilotOngoing}
+                                  targetTariff={hasTargetTariff}
+                                  contractValues={contractJSON}
+                                  {...formikProps}
+                                />
+                              ) : null}
+                              <Box mx={0} mt={2} mb={3}>
+                                <div className={classes.actionsContainer}>
+                                  {result?.contract_number === undefined && (
+                                    <Button
+                                      data-cy="prev"
+                                      className={classes.button}
+                                      startIcon={<ArrowBackIosIcon />}
+                                      disabled={activeStep === 0 || loading}
+                                      onClick={() => prevStep(formikProps)}>
+                                      {t('PAS_ANTERIOR')}
+                                    </Button>
+                                  )}
+                                  {activeStep < MAX_STEP_NUMBER - 1 ? (
+                                    <Button
+                                      type="button"
+                                      data-cy="next"
+                                      id="change-tariff-next-step-button"
+                                      className={classes.button}
+                                      variant="contained"
+                                      color="primary"
+                                      endIcon={<ArrowForwardIosIcon />}
+                                      disabled={!formikProps.isValid}
+                                      onClick={() => nextStep(formikProps)}>
+                                      {t('SEGUENT_PAS')}
+                                    </Button>
+                                  ) : (
+                                    !completed && (
                                       <Button
                                         type="button"
-                                        data-cy="next"
-                                        id="change-tariff-next-step-button"
+                                        data-cy="submit"
+                                        id="tariff-change-submit"
                                         className={classes.button}
                                         variant="contained"
                                         color="primary"
-                                        endIcon={<ArrowForwardIosIcon />}
-                                        disabled={!formikProps.isValid}
-                                        onClick={() => nextStep(formikProps)}>
-                                        {t('SEGUENT_PAS')}
+                                        startIcon={
+                                          loading ? (
+                                            <CircularProgress size={24} />
+                                          ) : (
+                                            <SendIcon />
+                                          )
+                                        }
+                                        disabled={
+                                          loading || !formikProps.isValid
+                                        }
+                                        onClick={() =>
+                                          handlePost(formikProps.values)
+                                        }>
+                                        {t('INDEXED_SUBMIT_BUTTON_TEXT')}
                                       </Button>
-                                    ) : (
-                                      !completed && (
-                                        <Button
-                                          type="button"
-                                          data-cy="submit"
-                                          id="tariff-change-submit"
-                                          className={classes.button}
-                                          variant="contained"
-                                          color="primary"
-                                          startIcon={
-                                            loading ? (
-                                              <CircularProgress size={24} />
-                                            ) : (
-                                              <SendIcon />
-                                            )
-                                          }
-                                          disabled={
-                                            loading || !formikProps.isValid
-                                          }
-                                          onClick={() =>
-                                            handlePost(formikProps.values)
-                                          }>
-                                          {t('INDEXED_SUBMIT_BUTTON_TEXT')}
-                                        </Button>
-                                      )
-                                    )}
-                                  </div>
-                                </Box>
-                              </>
-                            )}
+                                    )
+                                  )}
+                                </div>
+                              </Box>
+                            </>
+                          )}
 
-                            {completed && (
-                              <Paper
-                                elevation={0}
-                                className={classes.stepContainer}>
-                                {result ? (
-                                  <Success
-                                    showHeader={false}
-                                    title={t(
-                                      isTariffIndexed
-                                        ? 'PERIODS_SUCCESS_PAGE_TITLE'
-                                        : 'INDEXED_SUCCESS_PAGE_TITLE'
-                                    )}
-                                    subtitle={hasTargetTariff}
-                                    description={t(
-                                      isTariffIndexed
-                                        ? 'PERIODS_SUCCESS_PAGE_DESC'
-                                        : 'INDEXED_SUCCESS_PAGE_DESC'
-                                    )}
-                                  />
-                                ) : (
-                                  <Failure error={error} showHeader={false} />
-                                )}
-                              </Paper>
-                            )}
-                          </Container>
-                        </Form>
-                        {showInspector && (
-                          <DisplayFormikState {...formikProps} />
-                        )}
-                      </>
-                    )}
-                  </Formik>
-                </Grid>
-                <Grid item xs={3}>
-                  <DropDownMenu
-                    title={t('INDEXED_CONTRACT_CHARACTERISTICS')}
-                    sections={sectionsJson}
-                  />
-                </Grid>
+                          {completed && (
+                            <Paper
+                              elevation={0}
+                              className={classes.stepContainer}>
+                              {result ? (
+                                <Success
+                                  showHeader={false}
+                                  title={t(
+                                    isTariffIndexed
+                                      ? 'PERIODS_SUCCESS_PAGE_TITLE'
+                                      : 'INDEXED_SUCCESS_PAGE_TITLE'
+                                  )}
+                                  subtitle={hasTargetTariff}
+                                  description={t(
+                                    isTariffIndexed
+                                      ? 'PERIODS_SUCCESS_PAGE_DESC'
+                                      : 'INDEXED_SUCCESS_PAGE_DESC'
+                                  )}
+                                />
+                              ) : (
+                                <Failure error={error} showHeader={false} />
+                              )}
+                            </Paper>
+                          )}
+                        </Container>
+                      </Form>
+                      {showInspector && <DisplayFormikState {...formikProps} />}
+                    </>
+                  )}
+                </Formik>
               </Grid>
-            </MuiPickersUtilsProvider>
-          )}
-        </GlobalHotKeys>
-      )}
+              <Grid item xs={3}>
+                <DropDownMenu
+                  title={t('INDEXED_CONTRACT_CHARACTERISTICS')}
+                  sections={sectionsJson}
+                />
+              </Grid>
+            </Grid>
+          </MuiPickersUtilsProvider>
+        )}
+      </GlobalHotKeys>
     </>
   )
 }

--- a/src/containers/Indexed.js
+++ b/src/containers/Indexed.js
@@ -232,228 +232,229 @@ const Indexada = (props) => {
 
   if (loadingTariff) return <Loading />
 
+  if (checkEnabled && !hasTargetTariff)
+    return (
+      <GlobalHotKeys handlers={handlers} keyMap={keyMap}>
+        <Failure error={error} showHeader={false} />
+      </GlobalHotKeys>
+    )
+
   return (
     <>
       <GlobalHotKeys handlers={handlers} keyMap={keyMap}>
-        {checkEnabled && !hasTargetTariff ? (
-          <Failure error={error} showHeader={false} />
-        ) : (
-          <MuiPickersUtilsProvider utils={DayjsUtils}>
-            <Grid container justifyContent="space-between">
-              <Grid item xs={8}>
-                <Formik
-                  onSubmit={() => {}}
-                  enableReinitialize
-                  initialValues={initialValues}
-                  validationSchema={validationSchemas[activeStep]}
-                  validateOnMount={true}>
-                  {(formikProps) => (
-                    <>
-                      <Form
-                        id="cancelForm"
-                        method="POST"
-                        className={classes.root}
-                        noValidate
-                        autoComplete="off">
-                        <Container maxWidth="lg" disableGutters={true}>
-                          {!completed && (
-                            <>
-                              {activeStep !== 2 ? (
-                                <IndexedContractDetails
-                                  {...formikProps.values}
-                                  data={contractJSON}
-                                  targetTariff={hasTargetTariff}
-                                  isTariff20={isTariff20}
-                                  isTariffIndexed={isTariffIndexed}
-                                />
-                              ) : null}
+        <MuiPickersUtilsProvider utils={DayjsUtils}>
+          <Grid container justifyContent="space-between">
+            <Grid item xs={8}>
+              <Formik
+                onSubmit={() => {}}
+                enableReinitialize
+                initialValues={initialValues}
+                validationSchema={validationSchemas[activeStep]}
+                validateOnMount={true}>
+                {(formikProps) => (
+                  <>
+                    <Form
+                      id="cancelForm"
+                      method="POST"
+                      className={classes.root}
+                      noValidate
+                      autoComplete="off">
+                      <Container maxWidth="lg" disableGutters={true}>
+                        {!completed && (
+                          <>
+                            {activeStep !== 2 ? (
+                              <IndexedContractDetails
+                                {...formikProps.values}
+                                data={contractJSON}
+                                targetTariff={hasTargetTariff}
+                                isTariff20={isTariff20}
+                                isTariffIndexed={isTariffIndexed}
+                              />
+                            ) : null}
 
-                              {activeStep === 0 ? (
-                                <IndexedInfo
-                                  isTariff20={isTariff20}
-                                  isTariff30={isTariff30}
-                                  isTariffIndexed={isTariffIndexed}
-                                  desc={t(
-                                    isTariffIndexed
-                                      ? 'PERIODS_INTRO_BODY'
-                                      : 'INDEXED_INTRO_BODY',
-                                    {
-                                      url_tariff_index_characteristics: t(
-                                        isTariff20
-                                          ? 'TARIFF_CHARACTERISTICS_INDEX_20_URL'
-                                          : isTariff30
-                                          ? 'TARIFF_CHARACTERISTICS_INDEX_30_URL'
-                                          : 'TARIFF_CHARACTERISTICS_INDEX_6_URL'
-                                      ),
-                                      url_general_conditions: t(
-                                        'GENERAL_CONDITIONS_URL'
-                                      ),
-                                      url_specific_conditions: t(
-                                        'INDEXED_SPECIFIC_CONDITIONS_URL'
-                                      ),
-                                      url_tariff_characteristics: t(
-                                        isTariff20
-                                          ? 'TARIFF_CHARACTERISTICS_20_URL'
-                                          : isTariff30
-                                          ? 'TARIFF_CHARACTERISTICS_30_URL'
-                                          : 'TARIFF_CHARACTERISTICS_6_URL'
-                                      )
-                                    }
-                                  )}
-                                  {...formikProps}
-                                />
-                              ) : null}
-                              {activeStep === 1 ? (
-                                <IndexedInfo
-                                  isTariff20={isTariff20}
-                                  isTariff30={isTariff30}
-                                  isTariffIndexed={isTariffIndexed}
-                                  title={t('INDEXED_INTRO_TITLE')}
-                                  desc={
-                                    isTariffIndexed
-                                      ? t(
-                                          isTariff20
-                                            ? 'PERIODS_IMPORTANT_INFO_BODY'
-                                            : isTariff30
-                                            ? 'PERIODS_IMPORTANT_INFO_BODY_30'
-                                            : 'PERIODS_IMPORTANT_INFO_BODY_6',
-                                          {
-                                            url_tariff_characteristics: t(
-                                              isTariff20
-                                                ? 'TARIFF_CHARACTERISTICS_20_URL'
-                                                : isTariff30
-                                                ? 'TARIFF_CHARACTERISTICS_30_URL'
-                                                : 'TARIFF_CHARACTERISTICS_6_URL'
-                                            ),
-                                            url_tariff_web: t(
-                                              isTariff20
-                                                ? 'TARIFF_WEB_URL'
-                                                : isTariff30
-                                                ? 'TARIFF_WEB_30_URL'
-                                                : 'TARIFF_WEB_6_URL'
-                                            )
-                                          }
-                                        )
-                                      : t(
-                                          isTariff20
-                                            ? 'INDEXED_IMPORTANT_INFO_BODY'
-                                            : 'INDEXED_IMPORTANT_INFO_BODY_30',
-                                          {
-                                            url_indexada_help: t(
-                                              'TARIFF_INDEXED_HELP_URL'
-                                            )
-                                          }
-                                        )
+                            {activeStep === 0 ? (
+                              <IndexedInfo
+                                isTariff20={isTariff20}
+                                isTariff30={isTariff30}
+                                isTariffIndexed={isTariffIndexed}
+                                desc={t(
+                                  isTariffIndexed
+                                    ? 'PERIODS_INTRO_BODY'
+                                    : 'INDEXED_INTRO_BODY',
+                                  {
+                                    url_tariff_index_characteristics: t(
+                                      isTariff20
+                                        ? 'TARIFF_CHARACTERISTICS_INDEX_20_URL'
+                                        : isTariff30
+                                        ? 'TARIFF_CHARACTERISTICS_INDEX_30_URL'
+                                        : 'TARIFF_CHARACTERISTICS_INDEX_6_URL'
+                                    ),
+                                    url_general_conditions: t(
+                                      'GENERAL_CONDITIONS_URL'
+                                    ),
+                                    url_specific_conditions: t(
+                                      'INDEXED_SPECIFIC_CONDITIONS_URL'
+                                    ),
+                                    url_tariff_characteristics: t(
+                                      isTariff20
+                                        ? 'TARIFF_CHARACTERISTICS_20_URL'
+                                        : isTariff30
+                                        ? 'TARIFF_CHARACTERISTICS_30_URL'
+                                        : 'TARIFF_CHARACTERISTICS_6_URL'
+                                    )
                                   }
-                                  {...formikProps}
-                                />
-                              ) : null}
-                              {activeStep === 2 ? (
-                                <IndexedReview
-                                  isTariff20={isTariff20}
-                                  isTariffIndexed={isTariffIndexed}
-                                  isIndexedPilotOngoing={isIndexedPilotOngoing}
-                                  targetTariff={hasTargetTariff}
-                                  contractValues={contractJSON}
-                                  {...formikProps}
-                                />
-                              ) : null}
-                              <Box mx={0} mt={2} mb={3}>
-                                <div className={classes.actionsContainer}>
-                                  {result?.contract_number === undefined && (
-                                    <Button
-                                      data-cy="prev"
-                                      className={classes.button}
-                                      startIcon={<ArrowBackIosIcon />}
-                                      disabled={activeStep === 0 || loading}
-                                      onClick={() => prevStep(formikProps)}>
-                                      {t('PAS_ANTERIOR')}
-                                    </Button>
-                                  )}
-                                  {activeStep < MAX_STEP_NUMBER - 1 ? (
+                                )}
+                                {...formikProps}
+                              />
+                            ) : null}
+                            {activeStep === 1 ? (
+                              <IndexedInfo
+                                isTariff20={isTariff20}
+                                isTariff30={isTariff30}
+                                isTariffIndexed={isTariffIndexed}
+                                title={t('INDEXED_INTRO_TITLE')}
+                                desc={
+                                  isTariffIndexed
+                                    ? t(
+                                        isTariff20
+                                          ? 'PERIODS_IMPORTANT_INFO_BODY'
+                                          : isTariff30
+                                          ? 'PERIODS_IMPORTANT_INFO_BODY_30'
+                                          : 'PERIODS_IMPORTANT_INFO_BODY_6',
+                                        {
+                                          url_tariff_characteristics: t(
+                                            isTariff20
+                                              ? 'TARIFF_CHARACTERISTICS_20_URL'
+                                              : isTariff30
+                                              ? 'TARIFF_CHARACTERISTICS_30_URL'
+                                              : 'TARIFF_CHARACTERISTICS_6_URL'
+                                          ),
+                                          url_tariff_web: t(
+                                            isTariff20
+                                              ? 'TARIFF_WEB_URL'
+                                              : isTariff30
+                                              ? 'TARIFF_WEB_30_URL'
+                                              : 'TARIFF_WEB_6_URL'
+                                          )
+                                        }
+                                      )
+                                    : t(
+                                        isTariff20
+                                          ? 'INDEXED_IMPORTANT_INFO_BODY'
+                                          : 'INDEXED_IMPORTANT_INFO_BODY_30',
+                                        {
+                                          url_indexada_help: t(
+                                            'TARIFF_INDEXED_HELP_URL'
+                                          )
+                                        }
+                                      )
+                                }
+                                {...formikProps}
+                              />
+                            ) : null}
+                            {activeStep === 2 ? (
+                              <IndexedReview
+                                isTariff20={isTariff20}
+                                isTariffIndexed={isTariffIndexed}
+                                isIndexedPilotOngoing={isIndexedPilotOngoing}
+                                targetTariff={hasTargetTariff}
+                                contractValues={contractJSON}
+                                {...formikProps}
+                              />
+                            ) : null}
+                            <Box mx={0} mt={2} mb={3}>
+                              <div className={classes.actionsContainer}>
+                                {result?.contract_number === undefined && (
+                                  <Button
+                                    data-cy="prev"
+                                    className={classes.button}
+                                    startIcon={<ArrowBackIosIcon />}
+                                    disabled={activeStep === 0 || loading}
+                                    onClick={() => prevStep(formikProps)}>
+                                    {t('PAS_ANTERIOR')}
+                                  </Button>
+                                )}
+                                {activeStep < MAX_STEP_NUMBER - 1 ? (
+                                  <Button
+                                    type="button"
+                                    data-cy="next"
+                                    id="change-tariff-next-step-button"
+                                    className={classes.button}
+                                    variant="contained"
+                                    color="primary"
+                                    endIcon={<ArrowForwardIosIcon />}
+                                    disabled={!formikProps.isValid}
+                                    onClick={() => nextStep(formikProps)}>
+                                    {t('SEGUENT_PAS')}
+                                  </Button>
+                                ) : (
+                                  !completed && (
                                     <Button
                                       type="button"
-                                      data-cy="next"
-                                      id="change-tariff-next-step-button"
+                                      data-cy="submit"
+                                      id="tariff-change-submit"
                                       className={classes.button}
                                       variant="contained"
                                       color="primary"
-                                      endIcon={<ArrowForwardIosIcon />}
-                                      disabled={!formikProps.isValid}
-                                      onClick={() => nextStep(formikProps)}>
-                                      {t('SEGUENT_PAS')}
+                                      startIcon={
+                                        loading ? (
+                                          <CircularProgress size={24} />
+                                        ) : (
+                                          <SendIcon />
+                                        )
+                                      }
+                                      disabled={loading || !formikProps.isValid}
+                                      onClick={() =>
+                                        handlePost(formikProps.values)
+                                      }>
+                                      {t('INDEXED_SUBMIT_BUTTON_TEXT')}
                                     </Button>
-                                  ) : (
-                                    !completed && (
-                                      <Button
-                                        type="button"
-                                        data-cy="submit"
-                                        id="tariff-change-submit"
-                                        className={classes.button}
-                                        variant="contained"
-                                        color="primary"
-                                        startIcon={
-                                          loading ? (
-                                            <CircularProgress size={24} />
-                                          ) : (
-                                            <SendIcon />
-                                          )
-                                        }
-                                        disabled={
-                                          loading || !formikProps.isValid
-                                        }
-                                        onClick={() =>
-                                          handlePost(formikProps.values)
-                                        }>
-                                        {t('INDEXED_SUBMIT_BUTTON_TEXT')}
-                                      </Button>
-                                    )
-                                  )}
-                                </div>
-                              </Box>
-                            </>
-                          )}
+                                  )
+                                )}
+                              </div>
+                            </Box>
+                          </>
+                        )}
 
-                          {completed && (
-                            <Paper
-                              elevation={0}
-                              className={classes.stepContainer}>
-                              {result ? (
-                                <Success
-                                  showHeader={false}
-                                  title={t(
-                                    isTariffIndexed
-                                      ? 'PERIODS_SUCCESS_PAGE_TITLE'
-                                      : 'INDEXED_SUCCESS_PAGE_TITLE'
-                                  )}
-                                  subtitle={hasTargetTariff}
-                                  description={t(
-                                    isTariffIndexed
-                                      ? 'PERIODS_SUCCESS_PAGE_DESC'
-                                      : 'INDEXED_SUCCESS_PAGE_DESC'
-                                  )}
-                                />
-                              ) : (
-                                <Failure error={error} showHeader={false} />
-                              )}
-                            </Paper>
-                          )}
-                        </Container>
-                      </Form>
-                      {showInspector && <DisplayFormikState {...formikProps} />}
-                    </>
-                  )}
-                </Formik>
-              </Grid>
-              <Grid item xs={3}>
-                <DropDownMenu
-                  title={t('INDEXED_CONTRACT_CHARACTERISTICS')}
-                  sections={sectionsJson}
-                />
-              </Grid>
+                        {completed && (
+                          <Paper
+                            elevation={0}
+                            className={classes.stepContainer}>
+                            {result ? (
+                              <Success
+                                showHeader={false}
+                                title={t(
+                                  isTariffIndexed
+                                    ? 'PERIODS_SUCCESS_PAGE_TITLE'
+                                    : 'INDEXED_SUCCESS_PAGE_TITLE'
+                                )}
+                                subtitle={hasTargetTariff}
+                                description={t(
+                                  isTariffIndexed
+                                    ? 'PERIODS_SUCCESS_PAGE_DESC'
+                                    : 'INDEXED_SUCCESS_PAGE_DESC'
+                                )}
+                              />
+                            ) : (
+                              <Failure error={error} showHeader={false} />
+                            )}
+                          </Paper>
+                        )}
+                      </Container>
+                    </Form>
+                    {showInspector && <DisplayFormikState {...formikProps} />}
+                  </>
+                )}
+              </Formik>
             </Grid>
-          </MuiPickersUtilsProvider>
-        )}
+            <Grid item xs={3}>
+              <DropDownMenu
+                title={t('INDEXED_CONTRACT_CHARACTERISTICS')}
+                sections={sectionsJson}
+              />
+            </Grid>
+          </Grid>
+        </MuiPickersUtilsProvider>
       </GlobalHotKeys>
     </>
   )

--- a/src/containers/Indexed.js
+++ b/src/containers/Indexed.js
@@ -239,6 +239,33 @@ const Indexada = (props) => {
       </GlobalHotKeys>
     )
 
+  const translatedUrls = {
+    url_general_conditions: t('GENERAL_CONDITIONS_URL'),
+    url_specific_conditions: t('INDEXED_SPECIFIC_CONDITIONS_URL'),
+    url_indexada_help: t('TARIFF_INDEXED_HELP_URL'),
+    url_tariff_index_characteristics: t(
+      isTariff20
+        ? 'TARIFF_CHARACTERISTICS_INDEX_20_URL'
+        : isTariff30
+        ? 'TARIFF_CHARACTERISTICS_INDEX_30_URL'
+        : 'TARIFF_CHARACTERISTICS_INDEX_6_URL'
+    ),
+    url_tariff_characteristics: t(
+      isTariff20
+        ? 'TARIFF_CHARACTERISTICS_20_URL'
+        : isTariff30
+        ? 'TARIFF_CHARACTERISTICS_30_URL'
+        : 'TARIFF_CHARACTERISTICS_6_URL'
+    ),
+    url_tariff_web: t(
+      isTariff20
+        ? 'TARIFF_WEB_URL'
+        : isTariff30
+        ? 'TARIFF_WEB_30_URL'
+        : 'TARIFF_WEB_6_URL'
+    )
+  }
+
   return (
     <>
       <GlobalHotKeys handlers={handlers} keyMap={keyMap}>
@@ -281,28 +308,7 @@ const Indexada = (props) => {
                                   isTariffIndexed
                                     ? 'PERIODS_INTRO_BODY'
                                     : 'INDEXED_INTRO_BODY',
-                                  {
-                                    url_tariff_index_characteristics: t(
-                                      isTariff20
-                                        ? 'TARIFF_CHARACTERISTICS_INDEX_20_URL'
-                                        : isTariff30
-                                        ? 'TARIFF_CHARACTERISTICS_INDEX_30_URL'
-                                        : 'TARIFF_CHARACTERISTICS_INDEX_6_URL'
-                                    ),
-                                    url_general_conditions: t(
-                                      'GENERAL_CONDITIONS_URL'
-                                    ),
-                                    url_specific_conditions: t(
-                                      'INDEXED_SPECIFIC_CONDITIONS_URL'
-                                    ),
-                                    url_tariff_characteristics: t(
-                                      isTariff20
-                                        ? 'TARIFF_CHARACTERISTICS_20_URL'
-                                        : isTariff30
-                                        ? 'TARIFF_CHARACTERISTICS_30_URL'
-                                        : 'TARIFF_CHARACTERISTICS_6_URL'
-                                    )
-                                  }
+                                  translatedUrls
                                 )}
                                 {...formikProps}
                               />
@@ -321,32 +327,13 @@ const Indexada = (props) => {
                                           : isTariff30
                                           ? 'PERIODS_IMPORTANT_INFO_BODY_30'
                                           : 'PERIODS_IMPORTANT_INFO_BODY_6',
-                                        {
-                                          url_tariff_characteristics: t(
-                                            isTariff20
-                                              ? 'TARIFF_CHARACTERISTICS_20_URL'
-                                              : isTariff30
-                                              ? 'TARIFF_CHARACTERISTICS_30_URL'
-                                              : 'TARIFF_CHARACTERISTICS_6_URL'
-                                          ),
-                                          url_tariff_web: t(
-                                            isTariff20
-                                              ? 'TARIFF_WEB_URL'
-                                              : isTariff30
-                                              ? 'TARIFF_WEB_30_URL'
-                                              : 'TARIFF_WEB_6_URL'
-                                          )
-                                        }
+                                        translatedUrls
                                       )
                                     : t(
                                         isTariff20
                                           ? 'INDEXED_IMPORTANT_INFO_BODY'
                                           : 'INDEXED_IMPORTANT_INFO_BODY_30',
-                                        {
-                                          url_indexada_help: t(
-                                            'TARIFF_INDEXED_HELP_URL'
-                                          )
-                                        }
+                                        translatedUrls
                                       )
                                 }
                                 {...formikProps}

--- a/src/containers/Indexed.js
+++ b/src/containers/Indexed.js
@@ -47,12 +47,11 @@ const keyMap = {
   SHOW_INSPECTOR: 'ctrl+shift+d'
 }
 
-
 const Indexada = (props) => {
   const classes = useStyles()
   const { t, i18n } = useTranslation()
 
-  const { token, checkEnabled = true, isIndexedPilotOngoing=false } = props
+  const { token, checkEnabled = true, isIndexedPilotOngoing = false } = props
   const { language } = useParams()
 
   const [showInspector, setShowInspector] = useState(false)
@@ -75,7 +74,6 @@ const Indexada = (props) => {
   }
 
   const sectionsJson = useMemo(() => {
-
     let sectionsJson = [
       {
         title: t('GENERAL_CONDITIONS'),
@@ -83,15 +81,16 @@ const Indexada = (props) => {
       }
     ]
 
-    if(!isTariffIndexed){
-      sectionsJson.push({
-        title: t('INDEXED_SPECIFIC_CONDITIONS'),
-        text: t('INDEXED_SPECIFIC_CONDITIONS_TEXT')
-      },
-      {
-        title: t('INDEXED_MARGE'),
-        text: t('INDEXED_MARGE_TEXT', { kCoefficient: kCoefficient })
-      }
+    if (!isTariffIndexed) {
+      sectionsJson.push(
+        {
+          title: t('INDEXED_SPECIFIC_CONDITIONS'),
+          text: t('INDEXED_SPECIFIC_CONDITIONS_TEXT')
+        },
+        {
+          title: t('INDEXED_MARGE'),
+          text: t('INDEXED_MARGE_TEXT', { kCoefficient: kCoefficient })
+        }
       )
     }
 
@@ -108,13 +107,11 @@ const Indexada = (props) => {
     )
 
     return sectionsJson
-  },[isTariffIndexed, t, kCoefficient, hasTargetTariff])
-
-
+  }, [isTariffIndexed, t, kCoefficient, hasTargetTariff])
 
   const initialValues = {
     terms_accepted: false,
-    particular_contract_terms_accepted: false,
+    particular_contract_terms_accepted: false
   }
 
   const nextStep = (props) => {
@@ -147,14 +144,16 @@ const Indexada = (props) => {
     let params = {
       token: token,
       general_contract_terms_accepted: data.terms_accepted,
-      particular_contract_terms_accepted: data.particular_contract_terms_accepted
-     }
+      particular_contract_terms_accepted:
+        data.particular_contract_terms_accepted
+    }
 
     if (!isTariffIndexed) {
       // Not indexed, moving to an indexed, requiring those checks
       params.indexed_specific_terms_accepted = data.terms_accepted
       if (isIndexedPilotOngoing) {
-        params.indexed_pilot_legal_terms_accepted = data.indexed_legal_terms_accepted
+        params.indexed_pilot_legal_terms_accepted =
+          data.indexed_legal_terms_accepted
       }
     }
 
@@ -209,11 +208,12 @@ const Indexada = (props) => {
         .oneOf([true], t('UNACCEPTED_TERMS')),
       indexed_legal_terms_accepted: Yup.bool().when([], {
         is: () => !isTariffIndexed,
-        then: Yup.bool().required(t('UNACCEPTED_TERMS')) &&
-              Yup.bool().oneOf([true], t('UNACCEPTED_TERMS')),
-        otherwise: Yup.bool().notRequired(),
-    })
+        then:
+          Yup.bool().required(t('UNACCEPTED_TERMS')) &&
+          Yup.bool().oneOf([true], t('UNACCEPTED_TERMS')),
+        otherwise: Yup.bool().notRequired()
       })
+    })
   ]
 
   if (!contractJSON.name || !contractJSON.cups) {
@@ -274,31 +274,33 @@ const Indexada = (props) => {
                                     isTariff20={isTariff20}
                                     isTariff30={isTariff30}
                                     isTariffIndexed={isTariffIndexed}
-                                    desc={t(isTariffIndexed
-                                      ? 'PERIODS_INTRO_BODY'
-                                      : 'INDEXED_INTRO_BODY'
-                                      , {
-                                      url_tariff_index_characteristics: t(
-                                        isTariff20
-                                        ? 'TARIFF_CHARACTERISTICS_INDEX_20_URL'
-                                        : isTariff30
-                                        ? 'TARIFF_CHARACTERISTICS_INDEX_30_URL'
-                                        : 'TARIFF_CHARACTERISTICS_INDEX_6_URL'
+                                    desc={t(
+                                      isTariffIndexed
+                                        ? 'PERIODS_INTRO_BODY'
+                                        : 'INDEXED_INTRO_BODY',
+                                      {
+                                        url_tariff_index_characteristics: t(
+                                          isTariff20
+                                            ? 'TARIFF_CHARACTERISTICS_INDEX_20_URL'
+                                            : isTariff30
+                                            ? 'TARIFF_CHARACTERISTICS_INDEX_30_URL'
+                                            : 'TARIFF_CHARACTERISTICS_INDEX_6_URL'
                                         ),
-                                      url_general_conditions: t(
-                                        'GENERAL_CONDITIONS_URL'
-                                      ),
-                                      url_specific_conditions: t(
-                                        'INDEXED_SPECIFIC_CONDITIONS_URL'
-                                      ),
-                                      url_tariff_characteristics: t(
-                                        isTariff20
-                                        ? 'TARIFF_CHARACTERISTICS_20_URL'
-                                        : isTariff30
-                                        ? 'TARIFF_CHARACTERISTICS_30_URL'
-                                        : 'TARIFF_CHARACTERISTICS_6_URL'
-                                      )
-                                    })}
+                                        url_general_conditions: t(
+                                          'GENERAL_CONDITIONS_URL'
+                                        ),
+                                        url_specific_conditions: t(
+                                          'INDEXED_SPECIFIC_CONDITIONS_URL'
+                                        ),
+                                        url_tariff_characteristics: t(
+                                          isTariff20
+                                            ? 'TARIFF_CHARACTERISTICS_20_URL'
+                                            : isTariff30
+                                            ? 'TARIFF_CHARACTERISTICS_30_URL'
+                                            : 'TARIFF_CHARACTERISTICS_6_URL'
+                                        )
+                                      }
+                                    )}
                                     {...formikProps}
                                   />
                                 ) : null}
@@ -310,35 +312,39 @@ const Indexada = (props) => {
                                     title={t('INDEXED_INTRO_TITLE')}
                                     desc={
                                       isTariffIndexed
-                                      ? t(isTariff20
-                                        ? 'PERIODS_IMPORTANT_INFO_BODY'
-                                        : isTariff30
-                                        ? 'PERIODS_IMPORTANT_INFO_BODY_30'
-                                        : 'PERIODS_IMPORTANT_INFO_BODY_6',
-                                      {
-                                        url_tariff_characteristics: t(
-                                          isTariff20
-                                          ? 'TARIFF_CHARACTERISTICS_20_URL'
-                                          : isTariff30
-                                          ? 'TARIFF_CHARACTERISTICS_30_URL'
-                                          : 'TARIFF_CHARACTERISTICS_6_URL'
-                                        ),
-                                        url_tariff_web: t(
-                                          isTariff20
-                                          ? 'TARIFF_WEB_URL'
-                                          : isTariff30
-                                          ? 'TARIFF_WEB_30_URL'
-                                          : 'TARIFF_WEB_6_URL'
-                                        ),
-                                      })
-                                      : t(isTariff20
-                                        ? 'INDEXED_IMPORTANT_INFO_BODY'
-                                        : 'INDEXED_IMPORTANT_INFO_BODY_30',
-                                      {
-                                        url_indexada_help: t(
-                                          'TARIFF_INDEXED_HELP_URL'
-                                        ),
-                                      })
+                                        ? t(
+                                            isTariff20
+                                              ? 'PERIODS_IMPORTANT_INFO_BODY'
+                                              : isTariff30
+                                              ? 'PERIODS_IMPORTANT_INFO_BODY_30'
+                                              : 'PERIODS_IMPORTANT_INFO_BODY_6',
+                                            {
+                                              url_tariff_characteristics: t(
+                                                isTariff20
+                                                  ? 'TARIFF_CHARACTERISTICS_20_URL'
+                                                  : isTariff30
+                                                  ? 'TARIFF_CHARACTERISTICS_30_URL'
+                                                  : 'TARIFF_CHARACTERISTICS_6_URL'
+                                              ),
+                                              url_tariff_web: t(
+                                                isTariff20
+                                                  ? 'TARIFF_WEB_URL'
+                                                  : isTariff30
+                                                  ? 'TARIFF_WEB_30_URL'
+                                                  : 'TARIFF_WEB_6_URL'
+                                              )
+                                            }
+                                          )
+                                        : t(
+                                            isTariff20
+                                              ? 'INDEXED_IMPORTANT_INFO_BODY'
+                                              : 'INDEXED_IMPORTANT_INFO_BODY_30',
+                                            {
+                                              url_indexada_help: t(
+                                                'TARIFF_INDEXED_HELP_URL'
+                                              )
+                                            }
+                                          )
                                     }
                                     {...formikProps}
                                   />
@@ -347,7 +353,9 @@ const Indexada = (props) => {
                                   <IndexedReview
                                     isTariff20={isTariff20}
                                     isTariffIndexed={isTariffIndexed}
-                                    isIndexedPilotOngoing={isIndexedPilotOngoing}
+                                    isIndexedPilotOngoing={
+                                      isIndexedPilotOngoing
+                                    }
                                     targetTariff={hasTargetTariff}
                                     contractValues={contractJSON}
                                     {...formikProps}
@@ -416,13 +424,17 @@ const Indexada = (props) => {
                                 {result ? (
                                   <Success
                                     showHeader={false}
-                                    title={t(isTariffIndexed
-                                      ? 'PERIODS_SUCCESS_PAGE_TITLE'
-                                      : 'INDEXED_SUCCESS_PAGE_TITLE')}
+                                    title={t(
+                                      isTariffIndexed
+                                        ? 'PERIODS_SUCCESS_PAGE_TITLE'
+                                        : 'INDEXED_SUCCESS_PAGE_TITLE'
+                                    )}
                                     subtitle={hasTargetTariff}
-                                    description={t(isTariffIndexed
-                                      ? 'PERIODS_SUCCESS_PAGE_DESC'
-                                      : 'INDEXED_SUCCESS_PAGE_DESC')}
+                                    description={t(
+                                      isTariffIndexed
+                                        ? 'PERIODS_SUCCESS_PAGE_DESC'
+                                        : 'INDEXED_SUCCESS_PAGE_DESC'
+                                    )}
                                   />
                                 ) : (
                                   <Failure error={error} showHeader={false} />
@@ -441,7 +453,7 @@ const Indexada = (props) => {
                 <Grid item xs={3}>
                   <DropDownMenu
                     title={t('INDEXED_CONTRACT_CHARACTERISTICS')}
-                      sections={sectionsJson}
+                    sections={sectionsJson}
                   />
                 </Grid>
               </Grid>

--- a/src/containers/Indexed.js
+++ b/src/containers/Indexed.js
@@ -33,6 +33,7 @@ import Grid from '@material-ui/core/Grid'
 import DropDownMenu from '../components/DropDownMenu'
 import Loading from 'components/Loading'
 import IndexedInfo from './Indexed/IndexedInfo'
+import IndexedError from './Indexed/IndexedError'
 import { checkIsTariff20, checkIsTariff30 } from '../services/utils'
 import { checkIsTariffIndexed } from '../services/utils'
 
@@ -232,12 +233,20 @@ const Indexada = (props) => {
 
   if (loadingTariff) return <Loading />
 
+  const lesserErrors = [
+    'OPEN_CASES',
+    'STATE_CONFLICT',
+    'PENDING_CONTRACT_MODIFICATION',
+    'CUSTOM_TARIFF'
+  ]
+
   if (checkEnabled && !hasTargetTariff)
-    return (
-      <GlobalHotKeys handlers={handlers} keyMap={keyMap}>
-        <Failure error={error} showHeader={false} />
-      </GlobalHotKeys>
-    )
+    if (activeStep != 0 || !lesserErrors.includes(error?.code))
+      return (
+        <GlobalHotKeys handlers={handlers} keyMap={keyMap}>
+          <Failure error={error} showHeader={false} />
+        </GlobalHotKeys>
+      )
 
   const translatedUrls = {
     url_general_conditions: t('GENERAL_CONDITIONS_URL'),
@@ -270,7 +279,9 @@ const Indexada = (props) => {
     ? t('INDEXED_IMPORTANT_INFO_BODY', translatedUrls)
     : t('INDEXED_IMPORTANT_INFO_BODY_30', translatedUrls)
 
-  const introBody = isTariffIndexed
+  const introBody = error
+    ? IndexedError(t, error?.code, error?.data)
+    : isTariffIndexed
     ? t('PERIODS_INTRO_BODY', translatedUrls)
     : t('INDEXED_INTRO_BODY', translatedUrls)
 
@@ -357,7 +368,9 @@ const Indexada = (props) => {
                                     variant="contained"
                                     color="primary"
                                     endIcon={<ArrowForwardIosIcon />}
-                                    disabled={!formikProps.isValid}
+                                    disabled={
+                                      !formikProps.isValid || !hasTargetTariff
+                                    }
                                     onClick={() => nextStep(formikProps)}>
                                     {t('SEGUENT_PAS')}
                                   </Button>

--- a/src/containers/Indexed.js
+++ b/src/containers/Indexed.js
@@ -260,6 +260,20 @@ const Indexada = (props) => {
       : t('TARIFF_WEB_6_URL')
   }
 
+  const importantInfoBody = isTariffIndexed
+    ? isTariff20
+      ? t('PERIODS_IMPORTANT_INFO_BODY', translatedUrls)
+      : isTariff30
+      ? t('PERIODS_IMPORTANT_INFO_BODY_30', translatedUrls)
+      : t('PERIODS_IMPORTANT_INFO_BODY_6', translatedUrls)
+    : isTariff20
+    ? t('INDEXED_IMPORTANT_INFO_BODY', translatedUrls)
+    : t('INDEXED_IMPORTANT_INFO_BODY_30', translatedUrls)
+
+  const introBody = isTariffIndexed
+    ? t('PERIODS_INTRO_BODY', translatedUrls)
+    : t('INDEXED_INTRO_BODY', translatedUrls)
+
   return (
     <>
       <GlobalHotKeys handlers={handlers} keyMap={keyMap}>
@@ -298,12 +312,7 @@ const Indexada = (props) => {
                                 isTariff20={isTariff20}
                                 isTariff30={isTariff30}
                                 isTariffIndexed={isTariffIndexed}
-                                desc={
-                                  (isTariffIndexed
-                                    ? t('PERIODS_INTRO_BODY')
-                                    : t('INDEXED_INTRO_BODY'),
-                                  translatedUrls)
-                                }
+                                desc={introBody}
                                 {...formikProps}
                               />
                             ) : null}
@@ -313,19 +322,7 @@ const Indexada = (props) => {
                                 isTariff30={isTariff30}
                                 isTariffIndexed={isTariffIndexed}
                                 title={t('INDEXED_INTRO_TITLE')}
-                                desc={
-                                  isTariffIndexed
-                                    ? (isTariff20
-                                        ? t('PERIODS_IMPORTANT_INFO_BODY')
-                                        : isTariff30
-                                        ? t('PERIODS_IMPORTANT_INFO_BODY_30')
-                                        : t('PERIODS_IMPORTANT_INFO_BODY_6'),
-                                      translatedUrls)
-                                    : (isTariff20
-                                        ? t('INDEXED_IMPORTANT_INFO_BODY')
-                                        : t('INDEXED_IMPORTANT_INFO_BODY_30'),
-                                      translatedUrls)
-                                }
+                                desc={importantInfoBody}
                                 {...formikProps}
                               />
                             ) : null}

--- a/src/containers/Indexed.js
+++ b/src/containers/Indexed.js
@@ -243,27 +243,21 @@ const Indexada = (props) => {
     url_general_conditions: t('GENERAL_CONDITIONS_URL'),
     url_specific_conditions: t('INDEXED_SPECIFIC_CONDITIONS_URL'),
     url_indexada_help: t('TARIFF_INDEXED_HELP_URL'),
-    url_tariff_index_characteristics: t(
-      isTariff20
-        ? 'TARIFF_CHARACTERISTICS_INDEX_20_URL'
-        : isTariff30
-        ? 'TARIFF_CHARACTERISTICS_INDEX_30_URL'
-        : 'TARIFF_CHARACTERISTICS_INDEX_6_URL'
-    ),
-    url_tariff_characteristics: t(
-      isTariff20
-        ? 'TARIFF_CHARACTERISTICS_20_URL'
-        : isTariff30
-        ? 'TARIFF_CHARACTERISTICS_30_URL'
-        : 'TARIFF_CHARACTERISTICS_6_URL'
-    ),
-    url_tariff_web: t(
-      isTariff20
-        ? 'TARIFF_WEB_URL'
-        : isTariff30
-        ? 'TARIFF_WEB_30_URL'
-        : 'TARIFF_WEB_6_URL'
-    )
+    url_tariff_index_characteristics: isTariff20
+      ? t('TARIFF_CHARACTERISTICS_INDEX_20_URL')
+      : isTariff30
+      ? t('TARIFF_CHARACTERISTICS_INDEX_30_URL')
+      : t('TARIFF_CHARACTERISTICS_INDEX_6_URL'),
+    url_tariff_characteristics: isTariff20
+      ? t('TARIFF_CHARACTERISTICS_20_URL')
+      : isTariff30
+      ? t('TARIFF_CHARACTERISTICS_30_URL')
+      : t('TARIFF_CHARACTERISTICS_6_URL'),
+    url_tariff_web: isTariff20
+      ? t('TARIFF_WEB_URL')
+      : isTariff30
+      ? t('TARIFF_WEB_30_URL')
+      : t('TARIFF_WEB_6_URL')
   }
 
   return (

--- a/src/containers/Indexed.js
+++ b/src/containers/Indexed.js
@@ -298,12 +298,12 @@ const Indexada = (props) => {
                                 isTariff20={isTariff20}
                                 isTariff30={isTariff30}
                                 isTariffIndexed={isTariffIndexed}
-                                desc={t(
-                                  isTariffIndexed
-                                    ? 'PERIODS_INTRO_BODY'
-                                    : 'INDEXED_INTRO_BODY',
-                                  translatedUrls
-                                )}
+                                desc={
+                                  (isTariffIndexed
+                                    ? t('PERIODS_INTRO_BODY')
+                                    : t('INDEXED_INTRO_BODY'),
+                                  translatedUrls)
+                                }
                                 {...formikProps}
                               />
                             ) : null}
@@ -315,20 +315,16 @@ const Indexada = (props) => {
                                 title={t('INDEXED_INTRO_TITLE')}
                                 desc={
                                   isTariffIndexed
-                                    ? t(
-                                        isTariff20
-                                          ? 'PERIODS_IMPORTANT_INFO_BODY'
-                                          : isTariff30
-                                          ? 'PERIODS_IMPORTANT_INFO_BODY_30'
-                                          : 'PERIODS_IMPORTANT_INFO_BODY_6',
-                                        translatedUrls
-                                      )
-                                    : t(
-                                        isTariff20
-                                          ? 'INDEXED_IMPORTANT_INFO_BODY'
-                                          : 'INDEXED_IMPORTANT_INFO_BODY_30',
-                                        translatedUrls
-                                      )
+                                    ? (isTariff20
+                                        ? t('PERIODS_IMPORTANT_INFO_BODY')
+                                        : isTariff30
+                                        ? t('PERIODS_IMPORTANT_INFO_BODY_30')
+                                        : t('PERIODS_IMPORTANT_INFO_BODY_6'),
+                                      translatedUrls)
+                                    : (isTariff20
+                                        ? t('INDEXED_IMPORTANT_INFO_BODY')
+                                        : t('INDEXED_IMPORTANT_INFO_BODY_30'),
+                                      translatedUrls)
                                 }
                                 {...formikProps}
                               />

--- a/src/containers/Indexed.js
+++ b/src/containers/Indexed.js
@@ -232,9 +232,13 @@ const Indexada = (props) => {
 
   return (
     <>
-      {!loadingTariff ? (
+      {loadingTariff ? (
+        <Loading />
+      ) : (
         <GlobalHotKeys handlers={handlers} keyMap={keyMap}>
-          {!checkEnabled || hasTargetTariff ? (
+          {checkEnabled && !hasTargetTariff ? (
+            <Failure error={error} showHeader={false} />
+          ) : (
             <MuiPickersUtilsProvider utils={DayjsUtils}>
               <Grid container justifyContent="space-between">
                 <Grid item xs={8}>
@@ -442,12 +446,8 @@ const Indexada = (props) => {
                 </Grid>
               </Grid>
             </MuiPickersUtilsProvider>
-          ) : (
-            <Failure error={error} showHeader={false} />
           )}
         </GlobalHotKeys>
-      ) : (
-        <Loading />
       )}
     </>
   )

--- a/src/containers/Indexed.js
+++ b/src/containers/Indexed.js
@@ -280,10 +280,14 @@ const Indexada = (props) => {
     : t('INDEXED_IMPORTANT_INFO_BODY_30', translatedUrls)
 
   const introBody = error
-    ? indexedErrorText(t, error?.code, error?.data)
-    : isTariffIndexed
-    ? t('PERIODS_INTRO_BODY', translatedUrls)
-    : t('INDEXED_INTRO_BODY', translatedUrls)
+    ? <Alert severity='error'> {indexedErrorText(t, error?.code, error?.data)} </Alert>
+    : <div
+    dangerouslySetInnerHTML={{
+      __html: isTariffIndexed
+      ? t('PERIODS_INTRO_BODY', translatedUrls)
+      : t('INDEXED_INTRO_BODY', translatedUrls)
+    }}
+  />
 
   return (
     <>

--- a/src/containers/Indexed/IndexedContractDetails.js
+++ b/src/containers/Indexed/IndexedContractDetails.js
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next'
 import { makeStyles } from '@material-ui/core/styles'
 
 import LabelFieldRow from '../../components/oficinavirtual/LabelFieldRow'
-import { Alert } from '@material-ui/lab'
 
 const IndexedContractDetails = (props) => {
   const { t } = useTranslation()
@@ -19,9 +18,7 @@ const IndexedContractDetails = (props) => {
       </LabelFieldRow>
       <LabelFieldRow label={t('CURRENT_TARIFF')}>{data.tariff}</LabelFieldRow>
       <LabelFieldRow isHighlight={true} label={t('TARIFF_TO_CONTRACT')}>
-        <Alert severity="warning">
-          {targetTariff || t('TARIFF_CHANGE_NOT_AVAILABLE')}
-        </Alert>
+        {targetTariff || t('TARIFF_CHANGE_NOT_AVAILABLE')}
       </LabelFieldRow>
     </div>
   )

--- a/src/containers/Indexed/IndexedContractDetails.js
+++ b/src/containers/Indexed/IndexedContractDetails.js
@@ -32,6 +32,6 @@ const useStyles = makeStyles((theme) => ({
     marginBottom: '0.5rem'
   },
   highlight: {
-    color:  theme.palette.text.primary
+    color: theme.palette.text.primary
   }
 }))

--- a/src/containers/Indexed/IndexedContractDetails.js
+++ b/src/containers/Indexed/IndexedContractDetails.js
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { makeStyles } from '@material-ui/core/styles'
 
 import LabelFieldRow from '../../components/oficinavirtual/LabelFieldRow'
+import { Alert } from '@material-ui/lab'
 
 const IndexedContractDetails = (props) => {
   const { t } = useTranslation()
@@ -18,7 +19,9 @@ const IndexedContractDetails = (props) => {
       </LabelFieldRow>
       <LabelFieldRow label={t('CURRENT_TARIFF')}>{data.tariff}</LabelFieldRow>
       <LabelFieldRow isHighlight={true} label={t('TARIFF_TO_CONTRACT')}>
-        {targetTariff || t('TARIFF_CHANGE_NOT_AVAILABLE')}
+        <Alert severity="warning">
+          {targetTariff || t('TARIFF_CHANGE_NOT_AVAILABLE')}
+        </Alert>
       </LabelFieldRow>
     </div>
   )

--- a/src/containers/Indexed/IndexedContractDetails.js
+++ b/src/containers/Indexed/IndexedContractDetails.js
@@ -16,11 +16,9 @@ const IndexedContractDetails = (props) => {
       <LabelFieldRow label={t('CONTRACT')}>
         <p>{data.name}</p>
       </LabelFieldRow>
-      <LabelFieldRow label={t('CURRENT_TARIFF')}>
-        {data.tariff}
-      </LabelFieldRow>
+      <LabelFieldRow label={t('CURRENT_TARIFF')}>{data.tariff}</LabelFieldRow>
       <LabelFieldRow isHighlight={true} label={t('TARIFF_TO_CONTRACT')}>
-        {targetTariff}
+        {targetTariff || t('TARIFF_CHANGE_NOT_AVAILABLE')}
       </LabelFieldRow>
     </div>
   )

--- a/src/containers/Indexed/IndexedContractDetails.test.js
+++ b/src/containers/Indexed/IndexedContractDetails.test.js
@@ -10,16 +10,16 @@ jest.mock('react-i18next', () => ({
 }))
 
 describe('Test the correctly render', () => {
-  
-    const mockData = {
-        name:"mockName",
-        tariff:"mockTariff",
-    }
-    const mockTargetTariff = "mockTargetTariff" 
-
+  const mockData = {
+    name: 'mockName',
+    tariff: 'mockTariff'
+  }
+  const mockTargetTariff = 'mockTargetTariff'
 
   test('The component render properly all texts', () => {
-    render(<IndexedContractDetails data={mockData} targetTariff={mockTargetTariff} />)
+    render(
+      <IndexedContractDetails data={mockData} targetTariff={mockTargetTariff} />
+    )
     const contractElement = screen.getByText(mockData.name)
     const currentTariffElement = screen.getByText(mockData.tariff)
     const targetTariffElement = screen.getByText(mockTargetTariff)

--- a/src/containers/Indexed/IndexedError.js
+++ b/src/containers/Indexed/IndexedError.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useParams } from 'react-router-dom'
 
-export default function errorTxt(t, code, errorData) {
+export default function indexedErrorText(t, code, errorData) {
   const exceptionMap = {
     NO_CHANGES: t('INDEXED_NO_CHANGES_ERROR_TXT'),
     OPEN_CASES: t('INDEXED_OPEN_CASES_ERROR_TXT'),

--- a/src/containers/Indexed/IndexedError.js
+++ b/src/containers/Indexed/IndexedError.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { useParams } from 'react-router-dom'
+
+export default function errorTxt(t, code, errorData) {
+  const exceptionMap = {
+    NO_CHANGES: t('INDEXED_NO_CHANGES_ERROR_TXT'),
+    OPEN_CASES: t('INDEXED_OPEN_CASES_ERROR_TXT'),
+    STATE_CONFLICT: t('INDEXED_STATE_CONFLICT_ERROR_TXT'),
+    PENDING_CONTRACT_MODIFICATION: t('PENDING_CONTRACT_MODIFICATION_ERROR_TXT'),
+    CUSTOM_TARIFF: t('INDEXED_CUSTOM_TARIFF_ERROR_TXT'),
+    INVALID_FIELD: t('INVALID_FIELD', {
+      field_name: errorData?.[0]?.field || t('UNKNOWN_FIELD')
+    }),
+    UNAUTHORIZED: t('INDEXED_UNAUTHORIZED_ERROR_TXT'),
+    UNEXPECTED_ERROR: t('INDEXED_UNEXPECTED_ERROR_TXT', {
+      url: t('CONTACT_HELP_URL')
+    })
+  }
+  return exceptionMap[code] ?? exceptionMap.UNEXPECTED_ERROR
+}

--- a/src/containers/Indexed/IndexedFailure.js
+++ b/src/containers/Indexed/IndexedFailure.js
@@ -11,7 +11,7 @@ import CloseIcon from '@material-ui/icons/Close'
 
 import StepHeader from '../../components/StepHeader'
 import cuca from '../../images/cuca-marejada.svg'
-import IndexedError from './IndexedError'
+import indexedErrorText from './IndexedError'
 
 const useStyles = makeStyles((theme) => ({
   container: {
@@ -55,28 +55,6 @@ function Failure(props) {
   const classes = useStyles()
   const { error = false, showHeader = true } = props
 
-  const getErrorTxt = (code, errorData) => {
-    const exceptionMap = {
-      NO_CHANGES: t('INDEXED_NO_CHANGES_ERROR_TXT'),
-      OPEN_CASES: t('INDEXED_OPEN_CASES_ERROR_TXT'),
-      STATE_CONFLICT: t('INDEXED_STATE_CONFLICT_ERROR_TXT'),
-      PENDING_CONTRACT_MODIFICATION: t(
-        'PENDING_CONTRACT_MODIFICATION_ERROR_TXT'
-      ),
-      CUSTOM_TARIFF: t('INDEXED_CUSTOM_TARIFF_ERROR_TXT'),
-      INVALID_FIELD: t('INVALID_FIELD', {
-        field_name: errorData?.[0]?.field || t('UNKNOWN_FIELD')
-      }),
-      UNAUTHORIZED: t('INDEXED_UNAUTHORIZED_ERROR_TXT'),
-      UNEXPECTED_ERROR: t('INDEXED_UNEXPECTED_ERROR_TXT', {
-        url: t('CONTACT_HELP_URL')
-      })
-    }
-
-    let errorTxt = exceptionMap[code]
-    return errorTxt ? errorTxt : exceptionMap.UNEXPECTED_ERROR
-  }
-
   useEffect(() => {
     i18n.changeLanguage(language)
   }, [language, i18n])
@@ -95,7 +73,7 @@ function Failure(props) {
           className={classes.message}
           variant="body1"
           dangerouslySetInnerHTML={{
-            __html: IndexedError(t, error.code, error.data)
+            __html: indexedErrorText(t, error.code, error.data)
           }}
         />
         <Box mt={3} mb={1}>

--- a/src/containers/Indexed/IndexedFailure.js
+++ b/src/containers/Indexed/IndexedFailure.js
@@ -11,7 +11,7 @@ import CloseIcon from '@material-ui/icons/Close'
 
 import StepHeader from '../../components/StepHeader'
 import cuca from '../../images/cuca-marejada.svg'
-
+import IndexedError from './IndexedError'
 
 const useStyles = makeStyles((theme) => ({
   container: {
@@ -60,10 +60,12 @@ function Failure(props) {
       NO_CHANGES: t('INDEXED_NO_CHANGES_ERROR_TXT'),
       OPEN_CASES: t('INDEXED_OPEN_CASES_ERROR_TXT'),
       STATE_CONFLICT: t('INDEXED_STATE_CONFLICT_ERROR_TXT'),
-      PENDING_CONTRACT_MODIFICATION: t('PENDING_CONTRACT_MODIFICATION_ERROR_TXT'),
+      PENDING_CONTRACT_MODIFICATION: t(
+        'PENDING_CONTRACT_MODIFICATION_ERROR_TXT'
+      ),
       CUSTOM_TARIFF: t('INDEXED_CUSTOM_TARIFF_ERROR_TXT'),
-      INVALID_FIELD: t('INDEXED_INVALID_FIELD_ERROR', {
-        error_field: errorData?.[0]?.field || t('UNKNOWN_FIELD')
+      INVALID_FIELD: t('INVALID_FIELD', {
+        field_name: errorData?.[0]?.field || t('UNKNOWN_FIELD')
       }),
       UNAUTHORIZED: t('INDEXED_UNAUTHORIZED_ERROR_TXT'),
       UNEXPECTED_ERROR: t('INDEXED_UNEXPECTED_ERROR_TXT', {
@@ -93,10 +95,7 @@ function Failure(props) {
           className={classes.message}
           variant="body1"
           dangerouslySetInnerHTML={{
-            __html:
-              error?.code === undefined
-                ? getErrorTxt("UNEXPECTED_ERROR")
-                : getErrorTxt(error.code,error.data)
+            __html: IndexedError(t, error.code, error.data)
           }}
         />
         <Box mt={3} mb={1}>

--- a/src/containers/Indexed/IndexedInfo.js
+++ b/src/containers/Indexed/IndexedInfo.js
@@ -12,11 +12,7 @@ const IndexedInfo = ({ title, desc }) => {
       {title ? <Header>{title}</Header> : null}
       {desc ? (
         <Card>
-          <div
-            dangerouslySetInnerHTML={{
-              __html: desc
-            }}
-          />
+          {desc}
         </Card>
       ) : null}
     </div>

--- a/src/containers/Indexed/IndexedInfo.test.js
+++ b/src/containers/Indexed/IndexedInfo.test.js
@@ -1,43 +1,39 @@
-import IndexedInfo from "./IndexedInfo";
-import { render, screen } from "@testing-library/react";
+import IndexedInfo from './IndexedInfo'
+import { render, screen } from '@testing-library/react'
 
 jest.mock('react-i18next', () => ({
-    useTranslation: () => {
-      return {
-        t: (str) => str,
-      };
-    },
-  }));
+  useTranslation: () => {
+    return {
+      t: (str) => str
+    }
+  }
+}))
 
+describe('Test the correctly render', () => {
+  const mockTitle = 'MOCK TITLE'
+  const mockDescription = 'MOCK DESCRIPTION'
 
-describe("Test the correctly render", () => {
+  test('The component render properly all texts', () => {
+    render(<IndexedInfo title={mockTitle} desc={mockDescription} />)
+    const titleElement = screen.getByText(mockTitle)
+    const descElement = screen.getByText(mockDescription)
+    expect(descElement).toBeInTheDocument()
+    expect(titleElement).toBeInTheDocument()
+  })
 
-  const mockTitle = "MOCK TITLE";
-  const mockDescription = "MOCK DESCRIPTION";
+  test('The component render properly without title', () => {
+    render(<IndexedInfo desc={mockDescription} />)
+    const descElement = screen.getByText(mockDescription)
+    const titleElement = screen.queryByText(mockTitle)
+    expect(descElement).toBeInTheDocument()
+    expect(titleElement).toBeNull()
+  })
 
-
-  test("The component render properly all texts", () => {
-    render(<IndexedInfo title={mockTitle} desc={mockDescription} />);
-    const titleElement = screen.getByText(mockTitle);
-    const descElement = screen.getByText(mockDescription);
-    expect(descElement).toBeInTheDocument();
-    expect(titleElement).toBeInTheDocument();
-  });
-
-  test("The component render properly without title", () => {
-    render(<IndexedInfo desc={mockDescription} />);
-    const descElement = screen.getByText(mockDescription);
-    const titleElement = screen.queryByText(mockTitle);
-    expect(descElement).toBeInTheDocument();
-    expect(titleElement).toBeNull();
-  });
-
-  test("The component render properly without desc", () => {
-    render(<IndexedInfo title={mockTitle} />);
-    const descElement = screen.queryByText(mockDescription);
-    const titleElement = screen.getByText(mockTitle);
-    expect(descElement).toBeNull();
-    expect(titleElement).toBeInTheDocument();
-  });
-
-});
+  test('The component render properly without desc', () => {
+    render(<IndexedInfo title={mockTitle} />)
+    const descElement = screen.queryByText(mockDescription)
+    const titleElement = screen.getByText(mockTitle)
+    expect(descElement).toBeNull()
+    expect(titleElement).toBeInTheDocument()
+  })
+})

--- a/src/containers/Indexed/IndexedReview.js
+++ b/src/containers/Indexed/IndexedReview.js
@@ -1,9 +1,16 @@
 import React, { useState } from 'react'
 import IndexedReviewData from './IndexedReviewData'
 
-
 const IndexedReview = (props) => {
-  let { setFieldValue, contractValues, values, targetTariff, isTariff20, isTariffIndexed, isIndexedPilotOngoing } = props
+  let {
+    setFieldValue,
+    contractValues,
+    values,
+    targetTariff,
+    isTariff20,
+    isTariffIndexed,
+    isIndexedPilotOngoing
+  } = props
   const [open, setOpen] = useState(false)
   const [indexadaTermsAccepted, setIndexadaTermsAccepted] = useState(false)
   const [indexadaLegalTermsAccepted, setIndexadaLegalTermsAccepted] =

--- a/src/containers/Indexed/IndexedReview.test.js
+++ b/src/containers/Indexed/IndexedReview.test.js
@@ -1,11 +1,11 @@
 import IndexedReview from './IndexedReview'
-import {Suspense} from 'react'
+import { Suspense } from 'react'
 import Loading from 'components/Loading'
 import {
   fireEvent,
   render,
   screen,
-  queryByAttribute,
+  queryByAttribute
 } from '@testing-library/react'
 import { act } from 'react-dom/test-utils'
 
@@ -66,7 +66,10 @@ describe('Test that it correctly renders', () => {
       'change-tariff-indexada-terms-check'
     )
     fireEvent.click(indexedTermsCheck)
-    expect(mockSetFieldValue).toBeCalledWith("particular_contract_terms_accepted", true)
+    expect(mockSetFieldValue).toBeCalledWith(
+      'particular_contract_terms_accepted',
+      true
+    )
   })
 
   test('Should call the setFieldValues function to change legal terms', () => {
@@ -83,7 +86,10 @@ describe('Test that it correctly renders', () => {
       'change-tariff-indexada-legal-terms-check'
     )
     fireEvent.click(legalTermsCheck)
-    expect(mockSetFieldValue).toBeCalledWith("indexed_legal_terms_accepted", true)
+    expect(mockSetFieldValue).toBeCalledWith(
+      'indexed_legal_terms_accepted',
+      true
+    )
   })
 
   test('Should call the setFieldValues function to decline general terms', async () => {
@@ -100,14 +106,13 @@ describe('Test that it correctly renders', () => {
     act(() => {
       fireEvent.click(acceptTermsCheck)
     })
-    const declineTermsButton = await screen.findByText("I_DECLINE")
-    
+    const declineTermsButton = await screen.findByText('I_DECLINE')
+
     act(() => {
-        fireEvent.click(declineTermsButton)
+      fireEvent.click(declineTermsButton)
     })
 
-    expect(mockSetFieldValue).toBeCalledWith("terms_accepted",false)
-    
+    expect(mockSetFieldValue).toBeCalledWith('terms_accepted', false)
   })
 
   test('Should call the setFieldValues function to accept general terms', async () => {
@@ -124,14 +129,12 @@ describe('Test that it correctly renders', () => {
     act(() => {
       fireEvent.click(acceptTermsCheck)
     })
-    const declineTermsButton = await screen.findByText("I_ACCEPT")
-    
+    const declineTermsButton = await screen.findByText('I_ACCEPT')
+
     act(() => {
-        fireEvent.click(declineTermsButton)
+      fireEvent.click(declineTermsButton)
     })
 
-    expect(mockSetFieldValue).toBeCalledWith("terms_accepted",true)
-    
+    expect(mockSetFieldValue).toBeCalledWith('terms_accepted', true)
   })
-
 })

--- a/src/containers/Indexed/IndexedReviewData.js
+++ b/src/containers/Indexed/IndexedReviewData.js
@@ -70,7 +70,7 @@ const IndexedReviewData = (props) => {
     targetTariff,
     isTariff20,
     isTariffIndexed,
-    isIndexedPilotOngoing,
+    isIndexedPilotOngoing
   } = props
   const powers = JSON.parse(contractValues.powers)
 
@@ -88,9 +88,7 @@ const IndexedReviewData = (props) => {
           <Typography className={classes.sectionTitle} variant="h6">
             {t('SUMMARY_GROUP_PROCESS')}
           </Typography>
-          <IndexedReviewField
-            value={t('PROCESS_TYPE_TARIFF_CHANGE')}
-          />
+          <IndexedReviewField value={t('PROCESS_TYPE_TARIFF_CHANGE')} />
         </Grid>
         <Grid item xs={12} sm={6}>
           <Typography className={classes.sectionTitle} variant="h6">
@@ -205,7 +203,9 @@ const IndexedReviewData = (props) => {
           <LegalText
             language={contractValues?.language}
             documentName={
-              isTariffIndexed ? "general-contract-terms" : "general-and-indexed-specific-terms"
+              isTariffIndexed
+                ? 'general-contract-terms'
+                : 'general-and-indexed-specific-terms'
             }
           />
         </TermsDialog>
@@ -225,10 +225,11 @@ const IndexedReviewData = (props) => {
               <Typography
                 variant="body2"
                 dangerouslySetInnerHTML={{
-                  __html: t(isTariffIndexed
-                    ? 'PERIODS_ACCEPT_CONDITIONS'
-                    : 'INDEXED_ACCEPT_CONDITIONS'
-                    )
+                  __html: t(
+                    isTariffIndexed
+                      ? 'PERIODS_ACCEPT_CONDITIONS'
+                      : 'INDEXED_ACCEPT_CONDITIONS'
+                  )
                 }}
               />
             }
@@ -252,45 +253,47 @@ const IndexedReviewData = (props) => {
               <Typography
                 variant="body2"
                 dangerouslySetInnerHTML={{
-                  __html: t(isTariffIndexed
-                    ? 'PERIODS_ACCEPT_TERMS'
-                    : 'INDEXED_ACCEPT_TERMS'
+                  __html: t(
+                    isTariffIndexed
+                      ? 'PERIODS_ACCEPT_TERMS'
+                      : 'INDEXED_ACCEPT_TERMS'
                   )
                 }}
               />
             }
           />
           <Divider variant="middle" className={classes.dividerBottom} />
-
         </Grid>
-        { !isTariffIndexed && isIndexedPilotOngoing && (
-        <Grid item xs={12}>
-          <FormControlLabel
-            control={
-              <Checkbox
-                id="change-tariff-indexada-legal-terms-check"
-                name="legal_terms_accepted"
-                onClick={() =>
-                  handleIndexadaLegalTermsAccepted(!indexadaLegalTermsAccepted)
-                }
-                checked={values.indexed_legal_terms_accepted}
-                color="primary"
-              />
-            }
-            label={
-              <Typography
-                variant="body2"
-                dangerouslySetInnerHTML={{
-                  __html: t('INDEXED_ACCEPT_LEGAL_TERMS', {
-                    inscription_conditions_url: t(
-                      'TARIFF_INDEXADA_INSCRIPTION_CONDITIONS_URL'
+        {!isTariffIndexed && isIndexedPilotOngoing && (
+          <Grid item xs={12}>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  id="change-tariff-indexada-legal-terms-check"
+                  name="legal_terms_accepted"
+                  onClick={() =>
+                    handleIndexadaLegalTermsAccepted(
+                      !indexadaLegalTermsAccepted
                     )
-                  })
-                }}
-              />
-            }
-          />
-        </Grid>
+                  }
+                  checked={values.indexed_legal_terms_accepted}
+                  color="primary"
+                />
+              }
+              label={
+                <Typography
+                  variant="body2"
+                  dangerouslySetInnerHTML={{
+                    __html: t('INDEXED_ACCEPT_LEGAL_TERMS', {
+                      inscription_conditions_url: t(
+                        'TARIFF_INDEXADA_INSCRIPTION_CONDITIONS_URL'
+                      )
+                    })
+                  }}
+                />
+              }
+            />
+          </Grid>
         )}
       </Grid>
     </>

--- a/src/containers/Indexed/IndexedReviewData.test.js
+++ b/src/containers/Indexed/IndexedReviewData.test.js
@@ -1,5 +1,11 @@
 import IndexedReviewData from './IndexedReviewData'
-import { fireEvent, render, screen, queryByAttribute, within } from '@testing-library/react'
+import {
+  fireEvent,
+  render,
+  screen,
+  queryByAttribute,
+  within
+} from '@testing-library/react'
 
 jest.mock('react-i18next', () => ({
   useTranslation: () => {
@@ -10,8 +16,7 @@ jest.mock('react-i18next', () => ({
 }))
 
 describe('Test that it correctly renders', () => {
-
-  const getById = queryByAttribute.bind(null,'id')
+  const getById = queryByAttribute.bind(null, 'id')
 
   const mockContractValues = {
     isphisical: true,
@@ -28,14 +33,17 @@ describe('Test that it correctly renders', () => {
     donation: true,
     tariff: '2.0TD_SOM',
     powers:
-    '[{"value": "P1", "power": "\\"8.050\\""}, {"value": "P2", "power": "\\"8.050\\""}]'
+      '[{"value": "P1", "power": "\\"8.050\\""}, {"value": "P2", "power": "\\"8.050\\""}]'
   }
 
-  const mock30ContractPowers = '[{"value": "P1", "power": "\\"8.050\\""}, {"value": "P2", "power": "\\"8.050\\""}, {"value": "P3", "power": "\\"8.050\\""},{"value": "P4", "power": "\\"8.050\\""},{"value": "P5", "power": "\\"8.050\\""},{"value": "P6", "power": "\\"8.050\\""}]'
+  const mock30ContractPowers =
+    '[{"value": "P1", "power": "\\"8.050\\""}, {"value": "P2", "power": "\\"8.050\\""}, {"value": "P3", "power": "\\"8.050\\""},{"value": "P4", "power": "\\"8.050\\""},{"value": "P5", "power": "\\"8.050\\""},{"value": "P6", "power": "\\"8.050\\""}]'
 
-  const mockTargetTariff = "2.0TD Indexada Peninsula"
+  const mockTargetTariff = '2.0TD Indexada Peninsula'
 
-  let mockContractValuesNoPhisical = JSON.parse(JSON.stringify(mockContractValues))
+  let mockContractValuesNoPhisical = JSON.parse(
+    JSON.stringify(mockContractValues)
+  )
   mockContractValuesNoPhisical.isphisical = false
 
   const mockSetFieldValues = jest.fn()
@@ -63,7 +71,9 @@ describe('Test that it correctly renders', () => {
     const addressElement = screen.getByText(mockContractValues.address)
     const vatElement = screen.getByText(mockContractValues.owner_vat)
     const tariffElement = screen.getByText(mockTargetTariff)
-    const { getByText } = within(getById(dom.container,'VOLUNTARY_CENT__value'))
+    const { getByText } = within(
+      getById(dom.container, 'VOLUNTARY_CENT__value')
+    )
 
     expect(getByText('Sí')).toBeInTheDocument()
     expect(cupsElement).toBeInTheDocument()
@@ -73,7 +83,9 @@ describe('Test that it correctly renders', () => {
   })
 
   test('The component render properly all texts without donation', () => {
-    const mockContractValuesWithoutDonation = JSON.parse(JSON.stringify(mockContractValues))
+    const mockContractValuesWithoutDonation = JSON.parse(
+      JSON.stringify(mockContractValues)
+    )
     mockContractValuesWithoutDonation.donation = false
     const dom = render(
       <IndexedReviewData
@@ -88,9 +100,10 @@ describe('Test that it correctly renders', () => {
     const addressElement = screen.getByText(mockContractValues.address)
     const vatElement = screen.getByText(mockContractValues.owner_vat)
     const tariffElement = screen.getByText(mockTargetTariff)
-    const { getByText } = within(getById(dom.container,'VOLUNTARY_CENT__value'))
+    const { getByText } = within(
+      getById(dom.container, 'VOLUNTARY_CENT__value')
+    )
 
-    
     expect(cupsElement).toBeInTheDocument()
     expect(addressElement).toBeInTheDocument()
     expect(vatElement).toBeInTheDocument()
@@ -107,10 +120,9 @@ describe('Test that it correctly renders', () => {
         handleClick={mockHandleClick}
       />
     )
-    const acceptTermsCheck = getById(dom.container,'change-tarif-terms-check')
+    const acceptTermsCheck = getById(dom.container, 'change-tarif-terms-check')
     fireEvent.click(acceptTermsCheck)
     expect(mockHandleClick).toBeCalledTimes(1)
-  
   })
 
   test('Should call the handleIndexadaTermsAccepted function', () => {
@@ -123,11 +135,14 @@ describe('Test that it correctly renders', () => {
         handleIndexadaTermsAccepted={mockHandleIndexadaTermsAccepted}
       />
     )
-    const indexadaTermsCheck = getById(dom.container,'change-tariff-indexada-terms-check')
+    const indexadaTermsCheck = getById(
+      dom.container,
+      'change-tariff-indexada-terms-check'
+    )
     fireEvent.click(indexadaTermsCheck)
     expect(mockHandleIndexadaTermsAccepted).toBeCalledTimes(1)
   })
-  
+
   test('Should call the handleIndexadaLegalTermsAccepted function', () => {
     //TODO: click the check to accept the legal terms
     const dom = render(
@@ -141,13 +156,15 @@ describe('Test that it correctly renders', () => {
         isIndexedPilotOngoing={true}
       />
     )
-    const legalTermsCheck = getById(dom.container,'change-tariff-indexada-legal-terms-check')
+    const legalTermsCheck = getById(
+      dom.container,
+      'change-tariff-indexada-legal-terms-check'
+    )
     fireEvent.click(legalTermsCheck)
     expect(mockHandleIndexadaLegalTermsAccepted).toBeCalledTimes(1)
   })
 
   test('Should show the 6 powers of a 3.0 contract', () => {
-    
     let mock30ContractValues = JSON.parse(JSON.stringify(mockContractValues))
     mock30ContractValues.powers = mock30ContractPowers
     render(
@@ -162,19 +179,17 @@ describe('Test that it correctly renders', () => {
       />
     )
 
-    let counter = 0;
-    JSON.parse(mock30ContractPowers).forEach(element => {
-      counter ++;
+    let counter = 0
+    JSON.parse(mock30ContractPowers).forEach((element) => {
+      counter++
       const powerElement = screen.getByText(element.value)
       expect(powerElement).toBeInTheDocument()
     })
-    
+
     expect(counter).toBe(6)
-    
   })
 
   test('Should show the 2 powers of a 2.0 contract', () => {
-    
     render(
       <IndexedReviewData
         open={false}

--- a/src/containers/Indexed/IndexedReviewField.js
+++ b/src/containers/Indexed/IndexedReviewField.js
@@ -24,12 +24,10 @@ const useStyles = makeStyles((theme) => ({
   }
 }))
 
-
-
 const ReviewField = ({ label, value }) => {
   const classes = useStyles()
   return (
-    <div className={clsx(classes.field)} >
+    <div className={clsx(classes.field)}>
       {label !== false && (
         <div className="field__title">
           <Typography className={classes.label} variant="subtitle2">
@@ -38,7 +36,10 @@ const ReviewField = ({ label, value }) => {
         </div>
       )}
       <div className={clsx('field__value')}>
-        <Typography id={label+'__value'} className={classes.value} variant="body2">
+        <Typography
+          id={label + '__value'}
+          className={classes.value}
+          variant="body2">
           <>{value}</>
         </Typography>
       </div>

--- a/src/containers/Indexed/IndexedReviewField.test.js
+++ b/src/containers/Indexed/IndexedReviewField.test.js
@@ -1,33 +1,31 @@
-import IndexedReviewField from "./IndexedReviewField";
-import { render, screen } from "@testing-library/react";
+import IndexedReviewField from './IndexedReviewField'
+import { render, screen } from '@testing-library/react'
 
+describe('Test that it correctly renders', () => {
+  const mockLabel = 'MOCK LABEL'
+  const mockValue = 'MOCK VALUE'
 
-describe("Test that it correctly renders", () => {
-    const mockLabel = "MOCK LABEL";
-    const mockValue = "MOCK VALUE";
-    
+  test('The component render properly all texts', () => {
+    render(<IndexedReviewField label={mockLabel} value={mockValue} />)
+    const labelElement = screen.getByText(mockLabel)
+    const valueElement = screen.getByText(mockValue)
+    expect(labelElement).toBeInTheDocument()
+    expect(valueElement).toBeInTheDocument()
+  })
 
-    test("The component render properly all texts",() =>{
-        render(<IndexedReviewField label={mockLabel} value={mockValue}/>)
-        const labelElement = screen.getByText(mockLabel);
-        const valueElement = screen.getByText(mockValue);
-        expect(labelElement).toBeInTheDocument();
-        expect(valueElement).toBeInTheDocument();
-    })
+  test('The component render properly without label', () => {
+    render(<IndexedReviewField value={mockValue} />)
+    const labelElement = screen.queryByText(mockLabel)
+    const valueElement = screen.getByText(mockValue)
+    expect(labelElement).toBeNull()
+    expect(valueElement).toBeInTheDocument()
+  })
 
-    test("The component render properly without label",() =>{
-        render(<IndexedReviewField value={mockValue} />)
-        const labelElement = screen.queryByText(mockLabel);
-        const valueElement = screen.getByText(mockValue);
-        expect(labelElement).toBeNull();
-        expect(valueElement).toBeInTheDocument();
-    })
-
-    test("The component render properly without value",() =>{
-        render(<IndexedReviewField label={mockLabel} />)
-        const labelElement = screen.getByText(mockLabel);
-        const valueElement = screen.queryByText(mockValue);
-        expect(labelElement).toBeInTheDocument();
-        expect(valueElement).toBeNull();
-    })
+  test('The component render properly without value', () => {
+    render(<IndexedReviewField label={mockLabel} />)
+    const labelElement = screen.getByText(mockLabel)
+    const valueElement = screen.queryByText(mockValue)
+    expect(labelElement).toBeInTheDocument()
+    expect(valueElement).toBeNull()
+  })
 })

--- a/src/i18n/locale-ca.json
+++ b/src/i18n/locale-ca.json
@@ -612,6 +612,7 @@
     "TARIFF_MODE_INDEXED_URL": "https://ca.support.somenergia.coop/article/1272-la-tarifa-indexada",
     "TARIFF_MODE_TARIFF_COMPARISON": "Al Centre d’Ajuda pots veure una <a target='_blank' href=\"{{url}}\">comparació de les dues tarifes</a>.",
     "TARIFF_MODE_TARIFF_COMPARISON_URL": "https://ca.support.somenergia.coop/article/1331-comparacio-de-les-tarifes-per-periodes-i-indexades",
+    "TARIFF_CHANGE_NOT_AVAILABLE": "El canvi de tarifa no està disponible per a aquest contracte.",
     "CONTRACT_PARTICULAR_TERMS": "Amb l’acceptació d’aquestes condicions particulars, la persona o empresa contractant s’obliga al pagament del seu consum al preu que resulti de l’aplicació de la tarifa contractada.",
     "PEAK": "Punta",
     "VALLEY": "Vall",

--- a/src/i18n/locale-es.json
+++ b/src/i18n/locale-es.json
@@ -611,7 +611,7 @@
     "TARIFF_MODE_INDEXED_URL": "https://es.support.somenergia.coop/article/1273-la-tarifa-indexada",
     "TARIFF_MODE_TARIFF_COMPARISON": "En el Centro de Ayuda puedes ver una <a target='_blank' href=\"{{url}}\">comparación de las dos tarifas</a>.",
     "TARIFF_MODE_TARIFF_COMPARISON_URL": "https://es.support.somenergia.coop/article/1332-comparacion-de-las-tarifas-por-periodos-y-las-indexadas",
-    "TARIFF_CHANGE_NOT_AVAILABLE": "La tramitación del cambio de tarifa no està disponible para este contrato",
+    "TARIFF_CHANGE_NOT_AVAILABLE": "El cambio de tarifa no está disponible para este contrato.",
     "CONTRACT_PARTICULAR_TERMS": "Con la aceptación de estas condiciones particulares, la persona o empresa contratante se obliga al pago de su consumo al precio que resulte de la aplicación de la tarifa contratada.",
     "PEAK": "Punta",
     "VALLEY": "Valle",

--- a/src/i18n/locale-eu.json
+++ b/src/i18n/locale-eu.json
@@ -611,7 +611,7 @@
     "TARIFF_MODE_INDEXED_URL": "https://eu.support.somenergia.coop/article/1275-tarifa-indexatua",
     "TARIFF_MODE_TARIFF_COMPARISON": "Laguntza Gunean <a target='_blank' href=\"{{url}}\">bi tarifen konparazio</a> bat aurkituko duzu.",
     "TARIFF_MODE_TARIFF_COMPARISON_URL": "https://eu.support.somenergia.coop/article/1334-comparacion-de-las-tarifas-por-periodos-e-indexadas-euskera",
-    "TARIFF_CHANGE_NOT_AVAILABLE": "La tramitación del cambio de tarifa no està disponible para este contrato", 
+    "TARIFF_CHANGE_NOT_AVAILABLE": "La tramitación del cambio de tarifa no està disponible para este contrato",
     "CONTRACT_PARTICULAR_TERMS": "Baldintza berezi hauek onartzean, enpresa edo pertsona kontratugileak hitzematen du egindako kontsumoa kontratatutako tarifari aplikatzekoa zaion prezioan ordainduko duela.",
     "PEAK": "Puntakoa",
     "VALLEY": "Sakonunea",

--- a/src/i18n/locale-eu.json
+++ b/src/i18n/locale-eu.json
@@ -611,6 +611,7 @@
     "TARIFF_MODE_INDEXED_URL": "https://eu.support.somenergia.coop/article/1275-tarifa-indexatua",
     "TARIFF_MODE_TARIFF_COMPARISON": "Laguntza Gunean <a target='_blank' href=\"{{url}}\">bi tarifen konparazio</a> bat aurkituko duzu.",
     "TARIFF_MODE_TARIFF_COMPARISON_URL": "https://eu.support.somenergia.coop/article/1334-comparacion-de-las-tarifas-por-periodos-e-indexadas-euskera",
+    "TARIFF_CHANGE_NOT_AVAILABLE": "La tramitación del cambio de tarifa no està disponible para este contrato", 
     "CONTRACT_PARTICULAR_TERMS": "Baldintza berezi hauek onartzean, enpresa edo pertsona kontratugileak hitzematen du egindako kontsumoa kontratatutako tarifari aplikatzekoa zaion prezioan ordainduko duela.",
     "PEAK": "Puntakoa",
     "VALLEY": "Sakonunea",

--- a/src/i18n/locale-gl.json
+++ b/src/i18n/locale-gl.json
@@ -605,6 +605,7 @@
     "TARIFF_MODE_INDEXED_URL": "https://gl.support.somenergia.coop/article/1274-a-tarifa-indexada",
     "TARIFF_MODE_TARIFF_COMPARISON": "No Centro de Axuda podes ver unha <a target='_blank' href=\"{{url}}\">comparación das dúas tarifas</a>.",
     "TARIFF_MODE_TARIFF_COMPARISON_URL": "https://gl.support.somenergia.coop/article/1333-comparacion-de-las-tarifas-por-periodos-e-indexadas-gallego",
+    "TARIFF_CHANGE_NOT_AVAILABLE": "La tramitación del cambio de tarifa no està disponible para este contrato",
     "CONTRACT_PARTICULAR_TERMS": "Coa aceptación destas condicións particulares, a persoa ou empresa contratante obrígase ao pagamento do seu consumo ao prezo que resulte da aplicación da tarifa contratada.",
     "PEAK": "Punta",
     "VALLEY": "Val",


### PR DESCRIPTION
## Description

Show a less tragic error message when expected contract conditions blocking a tariff change

## Changes

- Refactor: Extract strings from the jsx to simplify indexed page component structure and logic
- Refactor: Early exits for Firefly Failure and Loading
- Refactor: Extract error text function to be shared among components
- Feature: detect the errors on the first page and instead of showing the dead firefly error
    -  show the normal page with the error as description
    - in the target tariff field put the text of op not available
    - disable the next button

## Observations

## Please, review

- Errors that are shown with the new and the old message
- With the new error (message in a box)
    - Inactive contract
    - Ongoing Modification
    - Ongoing ATR
    - Custom tarif
- With the old error (dead firefly)
    - No change (should not happen now)
    - Unexpected
    - Unauthorized
    - Invalid field

## How to check the new features

## Deploy notes


