### PR TITLE
🐛 Holder Change: Member information not sent from ui to api for homeowners communities

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -13,6 +13,7 @@ jobs:
         run: npm install
       - uses: cypress-io/github-action@v2
         with:
+          install-command: npm install
           browser: chrome
           record: true
           parallel: true

--- a/src/containers/HolderChange.js
+++ b/src/containers/HolderChange.js
@@ -289,18 +289,27 @@ function HolderChange(props) {
     i18n.changeLanguage(language)
   }, [language, i18n])
 
+  /// True if the step has to be skipped according to the values
+  const skipStep(page, values, isBackwards=false) {
+    // TODO: backwards is member was checked === true, check it still works
+    // without
+    switch (page) {
+      case 3: // BecomeMember
+        if (values?.holder?.ismember) return true
+        if (isHomeOwnerCommunityNif(values?.holder?.vat)) return true
+        return false
+      case 4: // MemberIdentifier
+        if (values?.holder?.ismember) return true
+        if (values?.member?.become_member === true) return true
+        return false
+    }
+    return false
+  }
+
   const nextStep = (values, actions) => {
     let next = activeStep + 1
-    if (next === 3 && values?.holder?.ismember) {
-      next += 2
-    }
-    if (next === 4 && values?.member?.become_member === true) {
-      next++
-    }
-    // Neighbour comunity cannot become a member
-    if (next === 3 && isHomeOwnerCommunityNif(values?.holder?.vat)) {
-      next += 1
-    }
+
+    while (skipStep(next, values, false)) next++
 
     const last = MAX_STEP_NUMBER
     setActiveStep(Math.min(next, last))
@@ -310,16 +319,9 @@ function HolderChange(props) {
 
   const prevStep = (values, actions) => {
     let prev = activeStep - 1
-    if (prev === 4 && values?.holder?.ismember === true) {
-      prev -= 2
-    }
-    if (prev === 4 && values?.member?.become_member === true) {
-      prev--
-    }
-    // Neighbour comunity cannot become a member
-    if (prev === 3 && isHomeOwnerCommunityNif(values?.holder?.vat)) {
-      prev -= 1
-    }
+
+    while (skipStep(prev, values, true)) prev--
+
     setActiveStep(Math.max(0, prev))
     actions.setTouched({})
     actions.setSubmitting(false)

--- a/src/containers/HolderChange.js
+++ b/src/containers/HolderChange.js
@@ -19,7 +19,6 @@ import SendIcon from '@material-ui/icons/Send'
 import Typography from '@material-ui/core/Typography'
 import Alert from '@material-ui/lab/Alert'
 
-
 import VAT from './HolderChange/VAT'
 import CUPS from './HolderChange/CUPS'
 import PersonalData from './HolderChange/PersonalData'
@@ -38,7 +37,6 @@ import DisplayFormikState from 'components/DisplayFormikState'
 
 import { holderChange } from 'services/api'
 import { normalizeHolderChange, isHomeOwnerCommunityNif } from 'services/utils'
-
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -243,7 +241,7 @@ function HolderChange(props) {
               merge: Yup.array()
                 .min(1, t('ELECTRODEP_ATTACH_REQUIRED'))
                 .max(1, t('ELECTRODEP_ATTACH_REQUIRED'))
-                .required(t('ELECTRODEP_ATTACH_REQUIRED')),
+                .required(t('ELECTRODEP_ATTACH_REQUIRED'))
             })
           })
       })
@@ -495,27 +493,29 @@ function HolderChange(props) {
                                 {!isLastStep ? t('SEGUENT_PAS') : t('SEND')}
                               </Button>
                             )}
-                         </div>
+                          </div>
                         </Box>
                         <Box mx={0} mt={2} mb={3}>
                           <div className={classes.actionsContainer}>
-                            {activeStep === 4 && (isHomeOwnerCommunityNif(props.values?.holder?.vat)) && (
-                              <>
-                                <Box mt={3}>
-                                  <Alert severity="warning">
-                                    <Typography
-                                      variant="body1"
-                                      dangerouslySetInnerHTML={{
-                                        __html: t('CIF_COMMUNITY_OWNERS')
-                                      }}
-                                    />
-                                  </Alert>
-                                </Box>
-                              </>
-                            )}
+                            {activeStep === 4 &&
+                              isHomeOwnerCommunityNif(
+                                props.values?.holder?.vat
+                              ) && (
+                                <>
+                                  <Box mt={3}>
+                                    <Alert severity="warning">
+                                      <Typography
+                                        variant="body1"
+                                        dangerouslySetInnerHTML={{
+                                          __html: t('CIF_COMMUNITY_OWNERS')
+                                        }}
+                                      />
+                                    </Alert>
+                                  </Box>
+                                </>
+                              )}
                           </div>
                         </Box>
-
                       </Paper>
                     }
                   </Form>

--- a/src/containers/HolderChange.js
+++ b/src/containers/HolderChange.js
@@ -290,8 +290,8 @@ function HolderChange(props) {
   }, [language, i18n])
 
   /// True if the step has to be skipped according to the values
-  const skipStep(step, values, isBackwards=false) {
-    // TODO: backwards is member was checked === true, check it still works
+  function skipStep(step, values, isBackwards = false) {
+    // TODO: backwards ismember was checked with "=== true", check it still works
     // without
     switch (step) {
       case 3: // BecomeMember

--- a/src/containers/HolderChange.js
+++ b/src/containers/HolderChange.js
@@ -37,7 +37,7 @@ import data from 'data/HolderChange/data.json'
 import DisplayFormikState from 'components/DisplayFormikState'
 
 import { holderChange } from 'services/api'
-import { normalizeHolderChange } from 'services/utils'
+import { normalizeHolderChange, isHomeOwnerCommunityNif } from 'services/utils'
 
 
 const useStyles = makeStyles((theme) => ({
@@ -298,7 +298,7 @@ function HolderChange(props) {
       next++
     }
     // Neighbour comunity cannot become a member
-    if (next === 3 && RegExp(/(^[H])/).test(values?.holder?.vat) === true) {
+    if (next === 3 && isHomeOwnerCommunityNif(values?.holder?.vat)) {
       next += 1
     }
 
@@ -317,7 +317,7 @@ function HolderChange(props) {
       prev--
     }
     // Neighbour comunity cannot become a member
-    if (prev === 3 && RegExp(/(^[H])/).test(values?.holder?.vat) === true) {
+    if (prev === 3 && isHomeOwnerCommunityNif(values?.holder?.vat)) {
       prev -= 1
     }
     setActiveStep(Math.max(0, prev))
@@ -500,7 +500,7 @@ function HolderChange(props) {
                         </Box>
                         <Box mx={0} mt={2} mb={3}>
                           <div className={classes.actionsContainer}>
-                            {activeStep === 4 && (RegExp(/(^[H])/).test(props.values?.holder?.vat)) && (
+                            {activeStep === 4 && (isHomeOwnerCommunityNif(props.values?.holder?.vat)) && (
                               <>
                                 <Box mt={3}>
                                   <Alert severity="warning">

--- a/src/containers/HolderChange.js
+++ b/src/containers/HolderChange.js
@@ -332,10 +332,7 @@ function HolderChange(props) {
     }
   }
 
-  const isLastStep = useMemo(
-    () => activeStep >= MAX_STEP_NUMBER - 1,
-    [activeStep]
-  )
+  const isLastStep = activeStep >= MAX_STEP_NUMBER - 1
 
   const handleError = async (error) => {
     let errorCode = error?.response?.data?.error?.code || 'UNEXPECTED'

--- a/src/containers/HolderChange.js
+++ b/src/containers/HolderChange.js
@@ -290,10 +290,10 @@ function HolderChange(props) {
   }, [language, i18n])
 
   /// True if the step has to be skipped according to the values
-  const skipStep(page, values, isBackwards=false) {
+  const skipStep(step, values, isBackwards=false) {
     // TODO: backwards is member was checked === true, check it still works
     // without
-    switch (page) {
+    switch (step) {
       case 3: // BecomeMember
         if (values?.holder?.ismember) return true
         if (isHomeOwnerCommunityNif(values?.holder?.vat)) return true

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -188,6 +188,10 @@ export const normalizeHolderChange = (contract) => {
     normalContract.member.become_member = false
     normalContract.member.link_member = false
   }
+  else if (isHomeOwnerCommunityNif(normalContract?.holder?.vat)) {
+    normalContract.member.become_member = false
+    normalContract.member.link_member = true
+  }
   'ismember' in normalContract?.holder && delete normalContract.holder.ismember
 
   if (!normalContract?.member?.link_member) {
@@ -545,3 +549,8 @@ export const checkIsTariff30 = (tariff) => {
 export const checkIsTariffIndexed = (tariff) => {
   return tariff.toLowerCase().match(/ndex/)
 }
+
+export const isHomeOwnerCommunityNif = (nif) => {
+  return /^H/.test(nif)
+}
+


### PR DESCRIPTION
Fix Owner/holder change form for homeowner comunities failing post

## Description

Context: Some months ago, we activated skipping the become member step for Homeowners communities as they can not become members and have to "link" another person as member.  The reason for that is that cooperative law does not allow them to be members.

When we skipped the step we forgot to set properly  become_member and link_member flags
As result, in the cannonicalize method, clears member information, as the member_link flag is not set, and the api fails when looking for it.

## Changes

- In case it is a community, set become_member=false and link_member=true
- This is different on what to do when the owner is already a member, in which case both flags were properly set to false. (See observations)
- Side refactor:
     - The logic to check for homeowner communities has been extracted to a service/utils.js:isHomeOnwerCommunityNif(nif)
     - The RegExp call has been simplified: no need to call the constructor, and removed (IOHO) useless parenthesis and claudators.
     - Extracted `skipStep` function for a more easy reading of wizard logic

## Observations

- TODO: The fourth state, with both become_member and link_member to true, is not valid. So those flags act as an enum, call it `member_mode` with three states: AlreadyMember, BecomeMember, LinkedMember. 

## Please, review

- We didn't check all cases (isMember...)

## How to check the new features

The failing case: https://secure.helpscout.net/conversation/2505922902/16467447?folderId=3063430

## Deploy notes

Nothing

