### PR TITLE
Fix matching cau and cups for single installs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+- Force CAU to match CUPS in single installs
+
 ## 2.3.5 2024-08-23
 
 - Matomo funnels tracking for Contract and NewMember forms

--- a/src/components/ApiValidatedField.jsx
+++ b/src/components/ApiValidatedField.jsx
@@ -23,8 +23,7 @@ export function ApiValidatedField({
   remoteCheck,
   helperText,
   autoFocus = false,
-  leadingIcon,
-  disabled
+  leadingIcon
 }) {
   const [isLoading, setIsLoading] = useState(false)
   const [formerValue, setFormerValue] = useState(undefined)
@@ -40,6 +39,7 @@ export function ApiValidatedField({
     }
     const result = localCheck(valueToCheck)
     const needsRemote = result.valid
+
     onChange({ ...result, valid: false })
     if (!needsRemote) return
     setIsLoading(true)
@@ -67,7 +67,6 @@ export function ApiValidatedField({
         label={label}
         variant={variant}
         fullWidth
-        disabled={disabled}
         required={required}
         autoFocus={autoFocus}
         value={value}

--- a/src/components/ApiValidatedField.jsx
+++ b/src/components/ApiValidatedField.jsx
@@ -23,7 +23,8 @@ export function ApiValidatedField({
   remoteCheck,
   helperText,
   autoFocus = false,
-  leadingIcon
+  leadingIcon,
+  disabled
 }) {
   const [isLoading, setIsLoading] = useState(false)
   const [formerValue, setFormerValue] = useState(undefined)
@@ -66,6 +67,7 @@ export function ApiValidatedField({
         label={label}
         variant={variant}
         fullWidth
+        disabled={disabled}
         required={required}
         autoFocus={autoFocus}
         value={value}
@@ -79,9 +81,9 @@ export function ApiValidatedField({
         }
         InputProps={{
           startAdornment: LeadingIcon && (
-            <InputAdornment sx={{ 
-              '& path': { color: 'rgba(0, 0, 0, 0.54)'}
-              }} position="start">
+            <InputAdornment sx={{
+              '& path': { color: 'rgba(0, 0, 0, 0.54)' }
+            }} position="start">
               <LeadingIcon />
             </InputAdornment>
           ),
@@ -93,7 +95,7 @@ export function ApiValidatedField({
                 <CheckOutlinedIcon color="primary" />
               ) : null}
             </InputAdornment>
-          ): null
+          ) : null
         }}
       />
     </>

--- a/src/components/CAUField.jsx
+++ b/src/components/CAUField.jsx
@@ -33,7 +33,7 @@ export function CAUField(props) {
     const collective_installation = props.data.collective_installation
     const cups = props.data.cups.slice(0, compact.length)
     if (collective_installation === false) {
-      const cau_cups = compact.slice(0, compact.length)      
+      const cau_cups = compact.slice(0, compact.length > 20 ? 20 : compact.length)      
       if (cau_cups !== cups) return { value, valid: false, error: t("CAU_NOT_MATCHING_CUPS") }
     }
     if (compact.length !== 26) return { value, valid: false, error: t("CAU_INVALID_LENGTH") }

--- a/src/components/CAUField.jsx
+++ b/src/components/CAUField.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { checkCups } from '../services/api'
 import SolarPowerIcon from '@mui/icons-material/WbSunny'
 import { useTranslation } from 'react-i18next'
@@ -26,33 +26,40 @@ export function CAUField(props) {
 
   function localCheck(value) {
     const compact = value.replaceAll(' ', '')
-    if (!compact) return {value, valid: false}
-    const borderPoint = compact.slice(20,22)
-    const installation = compact.slice(22,26)
-    if (compact.slice(0,2) !== "ES".slice(0,compact.length)) return {value, valid: false, error:t("CAU_INVALID_PREFIX")}
+    if (!compact) return { value, valid: false }
+    const borderPoint = compact.slice(20, 22)
+    const installation = compact.slice(22, 26)
+    if (compact.slice(0, 2) !== "ES".slice(0, compact.length)) return { value, valid: false, error: t("CAU_INVALID_PREFIX") }
     const collective_installation = props.data.collective_installation
-    const cups = props.data.cups.slice(0,compact.length)
-    if (collective_installation === false){
-      const cau_cups = compact.slice(0,compact.length)
-      if (cau_cups !== cups) return {value, valid: false, error:t("CAU_NOT_MATCHING_CUPS")}
+    const cups = props.data.cups.slice(0, compact.length)
+    if (collective_installation === false) {
+      const cau_cups = compact.slice(0, compact.length)      
+      if (cau_cups !== cups) return { value, valid: false, error: t("CAU_NOT_MATCHING_CUPS") }
     }
-    if (compact.length !== 26) return {value, valid: false, error:t("CAU_INVALID_LENGTH")}
-    if (borderPoint.length === 2 && !/^\d[A-Z]$/.test(borderPoint)) return {value, valid: false, error:t("CAU_INVALID_BORDER_POINT")}
-    if (installation.length === 4 && !/^A\d{1,3}$/.test(installation)) return {value, valid: false, error:t("CAU_INVALID_INSTALLATION")}
-    
-    return {value, valid: true}
+    if (compact.length !== 26) return { value, valid: false, error: t("CAU_INVALID_LENGTH") }
+    if (borderPoint.length === 2 && !/^\d[A-Z]$/.test(borderPoint)) return { value, valid: false, error: t("CAU_INVALID_BORDER_POINT") }
+    if (installation.length === 4 && !/^A\d{1,3}$/.test(installation)) return { value, valid: false, error: t("CAU_INVALID_INSTALLATION") }
+
+    return { value, valid: true }
   }
   function remoteCheck(value) {
-    return checkCups(value.replace(/ /g, '').slice(0,20))
+    return checkCups(value.replace(/ /g, '').slice(0, 20))
       .then((response) => {
         const valid = response?.state === true
-        return { value, valid, error: valid?undefined:t("CAU_INVALID_CONTROL_DIGIT") }
+        return { value, valid, error: valid ? undefined : t("CAU_INVALID_CONTROL_DIGIT") }
       })
       .catch((error) => {
         const valid = !!error?.response?.data?.state
-        return { value, valid, error: valid?undefined:t("CAU_INVALID_CONTROL_DIGIT")  }
+        return { value, valid, error: valid ? undefined : t("CAU_INVALID_CONTROL_DIGIT") }
       })
   }
+
+  useEffect(() => {
+    if (props.value) {
+      const result = localCheck(props.value)
+      props.onChange({ ...result, valid: false })
+    }
+  }, [props.values.self_consumption.collective_installation])
 
   return (
     <ApiValidatedField

--- a/src/components/CAUField.jsx
+++ b/src/components/CAUField.jsx
@@ -28,6 +28,12 @@ export function CAUField(props) {
     const compact = value.replaceAll(' ', '')
     const borderPoint = compact.slice(20,22)
     const installation = compact.slice(22,26)
+    const collective_installation = props.data.collective_installation
+    const cups = props.data.cups.slice(0,20)
+    if (collective_installation == false){
+      const cau_cups = compact.slice(0,20)
+      if (cau_cups != cups) return {value, valid: false, error:t("CAU_INVALID_CUPS")}
+    }
     if (!compact) return {value, valid: false}
     if (compact.slice(0,2) !== "ES".slice(0,compact.length)) return {value, valid: false, error:t("CAU_INVALID_PREFIX")}
     if (borderPoint.length === 2 && !/^\d[A-Z]$/.test(borderPoint)) return {value, valid: false, error:t("CAU_INVALID_BORDER_POINT")}

--- a/src/components/CAUField.jsx
+++ b/src/components/CAUField.jsx
@@ -26,19 +26,20 @@ export function CAUField(props) {
 
   function localCheck(value) {
     const compact = value.replaceAll(' ', '')
+    if (!compact) return {value, valid: false}
     const borderPoint = compact.slice(20,22)
     const installation = compact.slice(22,26)
-    const collective_installation = props.data.collective_installation
-    const cups = props.data.cups.slice(0,20)
-    if (collective_installation == false){
-      const cau_cups = compact.slice(0,20)
-      if (cau_cups != cups) return {value, valid: false, error:t("CAU_INVALID_CUPS")}
-    }
-    if (!compact) return {value, valid: false}
     if (compact.slice(0,2) !== "ES".slice(0,compact.length)) return {value, valid: false, error:t("CAU_INVALID_PREFIX")}
+    const collective_installation = props.data.collective_installation
+    const cups = props.data.cups.slice(0,compact.length)
+    if (collective_installation === false){
+      const cau_cups = compact.slice(0,compact.length)
+      if (cau_cups !== cups) return {value, valid: false, error:t("CAU_NOT_MATCHING_CUPS")}
+    }
+    if (compact.length !== 26) return {value, valid: false, error:t("CAU_INVALID_LENGTH")}
     if (borderPoint.length === 2 && !/^\d[A-Z]$/.test(borderPoint)) return {value, valid: false, error:t("CAU_INVALID_BORDER_POINT")}
     if (installation.length === 4 && !/^A\d{1,3}$/.test(installation)) return {value, valid: false, error:t("CAU_INVALID_INSTALLATION")}
-    if (compact.length !== 26) return {value, valid: false, error:t("CAU_INVALID_LENGTH")}
+    
     return {value, valid: true}
   }
   function remoteCheck(value) {

--- a/src/components/CAUField.jsx
+++ b/src/components/CAUField.jsx
@@ -31,14 +31,14 @@ export function CAUField(props) {
     const installation = compact.slice(22, 26)
     if (compact.slice(0, 2) !== "ES".slice(0, compact.length)) return { value, valid: false, error: t("CAU_INVALID_PREFIX") }
     const collective_installation = props.data.collective_installation
-    const cups = props.data.cups.slice(0, compact.length)
+    const cups = props.data.cups.slice(0, 20)
     if (collective_installation === false) {
-      const cau_cups = compact.slice(0, compact.length > 20 ? 20 : compact.length)      
+      const cau_cups = compact.slice(0, Math.min(compact.length,20))   
       if (cau_cups !== cups) return { value, valid: false, error: t("CAU_NOT_MATCHING_CUPS") }
     }
-    if (compact.length !== 26) return { value, valid: false, error: t("CAU_INVALID_LENGTH") }
     if (borderPoint.length === 2 && !/^\d[A-Z]$/.test(borderPoint)) return { value, valid: false, error: t("CAU_INVALID_BORDER_POINT") }
     if (installation.length === 4 && !/^A\d{1,3}$/.test(installation)) return { value, valid: false, error: t("CAU_INVALID_INSTALLATION") }
+    if (compact.length !== 26) return { value, valid: false, error: t("CAU_INVALID_LENGTH") }
 
     return { value, valid: true }
   }

--- a/src/containers/Contract.jsx
+++ b/src/containers/Contract.jsx
@@ -751,8 +751,7 @@ const Contract = (props) => {
       coordinates_accuracy: ''
     },
     self_consumption: {
-      have_installation: '',
-      collective_installation: undefined,
+      have_installation: ''
     },
     contract: {
       has_service: '',

--- a/src/containers/Contract.jsx
+++ b/src/containers/Contract.jsx
@@ -751,7 +751,8 @@ const Contract = (props) => {
       coordinates_accuracy: ''
     },
     self_consumption: {
-      have_installation: ''
+      have_installation: '',
+      collective_installation: undefined,
     },
     contract: {
       has_service: '',

--- a/src/containers/Contract/SelfConsumptionDetails.jsx
+++ b/src/containers/Contract/SelfConsumptionDetails.jsx
@@ -146,8 +146,10 @@ const SelfConsumptionDetails = (props) => {
             label={t('CAU')}
             variant="outlined"
             fullWidth
+            values={values}
             value={values.self_consumption.cau}
             onChange={handleChangeCAU}
+            disabled={props.values.self_consumption.collective_installation === undefined}
             onBlur={handleBlur}
             error={
               values?.self_consumption?.cau && !!errors?.self_consumption?.cau

--- a/src/containers/Contract/SelfConsumptionDetails.jsx
+++ b/src/containers/Contract/SelfConsumptionDetails.jsx
@@ -362,6 +362,7 @@ const SelfConsumptionDetails = (props) => {
             }}
             sx={{
               fontWeight: 500,
+              mt: 2,
               mb: 2
             }}
           />

--- a/src/containers/Contract/SelfConsumptionDetails.jsx
+++ b/src/containers/Contract/SelfConsumptionDetails.jsx
@@ -149,7 +149,6 @@ const SelfConsumptionDetails = (props) => {
             values={values}
             value={values.self_consumption.cau}
             onChange={handleChangeCAU}
-            disabled={props.values.self_consumption.collective_installation === undefined}
             onBlur={handleBlur}
             error={
               values?.self_consumption?.cau && !!errors?.self_consumption?.cau

--- a/src/containers/Contract/SelfConsumptionDetails.jsx
+++ b/src/containers/Contract/SelfConsumptionDetails.jsx
@@ -162,6 +162,10 @@ const SelfConsumptionDetails = (props) => {
                 </a>
               )
             }
+            data={{
+              'collective_installation': props.values.self_consumption.collective_installation,
+              'cups': props.values.supply_point.cups,
+            }}
           />
         </Grid>
         <Grid item xs={12}>

--- a/src/containers/Contract/SelfConsumptionDetails.jsx
+++ b/src/containers/Contract/SelfConsumptionDetails.jsx
@@ -93,40 +93,6 @@ const SelfConsumptionDetails = (props) => {
       <StepHeader title={t('SELFCONSUMPTION_DETAILS_TITLE')} />
       <Grid container spacing={3}>
         <Grid item xs={12}>
-          <Typography
-            variant="body1"
-            dangerouslySetInnerHTML={{ __html: t('SELFCONSUMPTION_CAU_CODE') }}
-            sx={{
-              fontWeight: 500,
-              mb: 2
-            }}
-          />
-          <CAUField
-            required
-            id="self_consumption_cau"
-            name="self_consumption.cau"
-            label={t('CAU')}
-            variant="outlined"
-            fullWidth
-            value={values.self_consumption.cau}
-            onChange={handleChangeCAU}
-            onBlur={handleBlur}
-            error={
-              values?.self_consumption?.cau && !!errors?.self_consumption?.cau
-            }
-            helperText={
-              errors?.self_consumption?.cau || (
-                <a
-                  href={t('SELFCONSUMPTION_CAU_HELP_URL')}
-                  target="_blank"
-                  rel="noopener noreferrer">
-                  {t('SELFCONSUMPTION_CAU_HELP')}
-                </a>
-              )
-            }
-          />
-        </Grid>
-        <Grid item xs={12}>
           <Chooser
             name="self_consumption.collective_installation"
             sx={{
@@ -162,6 +128,40 @@ const SelfConsumptionDetails = (props) => {
                 description: t('SELFCONSUMPTION_COLLECTIVE_INSTALLATION_HELP')
               }
             ]}
+          />
+        </Grid>
+        <Grid item xs={12}>
+          <Typography
+            variant="body1"
+            dangerouslySetInnerHTML={{ __html: t('SELFCONSUMPTION_CAU_CODE') }}
+            sx={{
+              fontWeight: 500,
+              mb: 2
+            }}
+          />
+          <CAUField
+            required
+            id="self_consumption_cau"
+            name="self_consumption.cau"
+            label={t('CAU')}
+            variant="outlined"
+            fullWidth
+            value={values.self_consumption.cau}
+            onChange={handleChangeCAU}
+            onBlur={handleBlur}
+            error={
+              values?.self_consumption?.cau && !!errors?.self_consumption?.cau
+            }
+            helperText={
+              errors?.self_consumption?.cau || (
+                <a
+                  href={t('SELFCONSUMPTION_CAU_HELP_URL')}
+                  target="_blank"
+                  rel="noopener noreferrer">
+                  {t('SELFCONSUMPTION_CAU_HELP')}
+                </a>
+              )
+            }
           />
         </Grid>
         <Grid item xs={12}>

--- a/src/containers/Success.jsx
+++ b/src/containers/Success.jsx
@@ -38,15 +38,13 @@ const Success = (props) => {
         alignItems: 'center'
       }}>
         <Avatar sx={{
-          width: 6,
-          height: 6,
           color: 'primary.main',
           backgroundColor: 'transparent',
           border: '2px solid',
           borderColor: 'primary.main',
           mb: 3
         }}>
-          <DoneIcon fontSize="large" />
+          <DoneIcon fontSize="medium" />
         </Avatar>
 
         <Typography id="success-page-title" sx={{

--- a/src/i18n/locale-ca.json
+++ b/src/i18n/locale-ca.json
@@ -694,6 +694,7 @@
     "CAU_INVALID_INSTALLATION": "El codi CAU ha d'acabar amb A i tres números",
     "CAU_INVALID_LENGTH": "El codi CAU ha de tenir 26 caràcters",
     "CAU_INVALID_CONTROL_DIGIT": "El codi CAU no és vàlid",
+    "CAU_INVALID_CUPS": "El codi CAU no coincidex amb els 20 primers caràcters del CUPS",
     "GENERATION_CONTRIBUTION_NO_MEMBER_VAT": "Introdueix el teu DNI o NIF",
     "GENERATION_BUTTON_ADD_ASSIGNMENT": "Assignar nou contracte",
     "GENERATION_ADD_ASSIGNMENTS_INFO_MSG": "Tingues en compte que només pots afegir contractes dels quals ets titular. Si vols afegir un contracte d’una altra persona, escriu-nos un correu electrònic a <a href=\"mailto:generationkwh@somenergia.coop\">generationkwh@somenergia.coop.</a>",

--- a/src/i18n/locale-ca.json
+++ b/src/i18n/locale-ca.json
@@ -694,7 +694,7 @@
     "CAU_INVALID_INSTALLATION": "El codi CAU ha d'acabar amb A i tres números",
     "CAU_INVALID_LENGTH": "El codi CAU ha de tenir 26 caràcters",
     "CAU_INVALID_CONTROL_DIGIT": "El codi CAU no és vàlid",
-    "CAU_INVALID_CUPS": "El codi CAU no coincidex amb els 20 primers caràcters del CUPS",
+    "CAU_NOT_MATCHING_CUPS": "El codi CAU no coincidex amb els 20 primers caràcters del CUPS",
     "GENERATION_CONTRIBUTION_NO_MEMBER_VAT": "Introdueix el teu DNI o NIF",
     "GENERATION_BUTTON_ADD_ASSIGNMENT": "Assignar nou contracte",
     "GENERATION_ADD_ASSIGNMENTS_INFO_MSG": "Tingues en compte que només pots afegir contractes dels quals ets titular. Si vols afegir un contracte d’una altra persona, escriu-nos un correu electrònic a <a href=\"mailto:generationkwh@somenergia.coop\">generationkwh@somenergia.coop.</a>",

--- a/src/i18n/locale-es.json
+++ b/src/i18n/locale-es.json
@@ -694,7 +694,7 @@
     "CAU_INVALID_INSTALLATION": "El código CAU debe acabar con A y tres números",
     "CAU_INVALID_LENGTH": "El código CAU ha de tener 26 caracteres",
     "CAU_INVALID_CONTROL_DIGIT": "El código CAU no es válido",
-    "CAU_INVALID_CUPS": "El código CAU no coincide con los 20 primeros carácteres del CUPS",
+    "CAU_NOT_MATCHING_CUPS": "El código CAU no coincide con los 20 primeros carácteres del CUPS",
     "GENERATION_CONTRIBUTION_NO_MEMBER_VAT":"Introduce tu DNI o NIF",
     "GENERATION_BUTTON_ADD_ASSIGNMENT":"Asignar nuevo contrato",
     "GENERATION_ADD_ASSIGNMENTS_INFO_MSG":"Ten en cuenta que solo puedes añadir contratos de los que eres titular. Si quieres añadir un contrato de otra persona, escríbenos un correo electrónico a <a href=\"mailto:generationkwh@somenergia.coop\">generationkwh@somenergia.coop</a>.",

--- a/src/i18n/locale-es.json
+++ b/src/i18n/locale-es.json
@@ -694,6 +694,7 @@
     "CAU_INVALID_INSTALLATION": "El código CAU debe acabar con A y tres números",
     "CAU_INVALID_LENGTH": "El código CAU ha de tener 26 caracteres",
     "CAU_INVALID_CONTROL_DIGIT": "El código CAU no es válido",
+    "CAU_INVALID_CUPS": "El código CAU no coincide con los 20 primeros carácteres del CUPS",
     "GENERATION_CONTRIBUTION_NO_MEMBER_VAT":"Introduce tu DNI o NIF",
     "GENERATION_BUTTON_ADD_ASSIGNMENT":"Asignar nuevo contrato",
     "GENERATION_ADD_ASSIGNMENTS_INFO_MSG":"Ten en cuenta que solo puedes añadir contratos de los que eres titular. Si quieres añadir un contrato de otra persona, escríbenos un correo electrónico a <a href=\"mailto:generationkwh@somenergia.coop\">generationkwh@somenergia.coop</a>.",

--- a/src/i18n/locale-eu.json
+++ b/src/i18n/locale-eu.json
@@ -692,7 +692,7 @@
     "CAU_INVALID_INSTALLATION": "CAU kodeak A eta hiru zenbakirekin amaitu behar du",
     "CAU_INVALID_LENGTH": "CAU kodeak 26 karaktere izan behar ditu",
     "CAU_INVALID_CONTROL_DIGIT": "CAU kodea ez da baliozkoa",
-    "CAU_INVALID_CUPS": "CAU kodea ez dator bat CUPSen lehen 20 karaktereekin",
+    "CAU_NOT_MATCHING_CUPS": "CAU kodea ez dator bat CUPSen lehen 20 karaktereekin",
     "GENERATION_CONTRIBUTION_NO_MEMBER_VAT": "Idatzi zure NAN zenbakia edo IFZ",
     "GENERATION_BUTTON_ADD_ASSIGNMENT": "Kontratu berria esleitu",
     "GENERATION_ADD_ASSIGNMENTS_INFO_MSG": "Kontuan hartu titular zaren kontratuak bakarrik gehitu ditzakezula. Beste norbaiten kontratu bat gehitu nahi baduzu, bidali mezu bat <a href=\"mailto:generationkwh@somenergia.coop\">generationkwh@somenergia.coop</a> helbidera.",

--- a/src/i18n/locale-eu.json
+++ b/src/i18n/locale-eu.json
@@ -692,6 +692,7 @@
     "CAU_INVALID_INSTALLATION": "CAU kodeak A eta hiru zenbakirekin amaitu behar du",
     "CAU_INVALID_LENGTH": "CAU kodeak 26 karaktere izan behar ditu",
     "CAU_INVALID_CONTROL_DIGIT": "CAU kodea ez da baliozkoa",
+    "CAU_INVALID_CUPS": "CAU kodea ez dator bat CUPSen lehen 20 karaktereekin",
     "GENERATION_CONTRIBUTION_NO_MEMBER_VAT": "Idatzi zure NAN zenbakia edo IFZ",
     "GENERATION_BUTTON_ADD_ASSIGNMENT": "Kontratu berria esleitu",
     "GENERATION_ADD_ASSIGNMENTS_INFO_MSG": "Kontuan hartu titular zaren kontratuak bakarrik gehitu ditzakezula. Beste norbaiten kontratu bat gehitu nahi baduzu, bidali mezu bat <a href=\"mailto:generationkwh@somenergia.coop\">generationkwh@somenergia.coop</a> helbidera.",

--- a/src/i18n/locale-gl.json
+++ b/src/i18n/locale-gl.json
@@ -687,7 +687,7 @@
     "CAU_INVALID_INSTALLATION": "O código CAU debe rematar con A e tres números",
     "CAU_INVALID_LENGTH": "O código CAU debe ter 26 caracteres",
     "CAU_INVALID_CONTROL_DIGIT": "O código CAU non é válido",
-    "CAU_INVALID_CUPS": "O código CAU non coincide cos 20 primeiros caracteres do CUPS",
+    "CAU_NOT_MATCHING_CUPS": "O código CAU non coincide cos 20 primeiros caracteres do CUPS",
     "GENERATION_CONTRIBUTION_NO_MEMBER_VAT": "Insire o teu DNI ou NIF",
     "GENERATION_BUTTON_ADD_ASSIGNMENT": "Asignar un novo contrato",
     "GENERATION_ADD_ASSIGNMENTS_INFO_MSG": "Ten en conta que só podes engadir contratos dos que es titular. Se queres engadir un contrato doutra persoa, escríbenos un correo electrónico a <a href=\"mailto:generationkwh@somenergia.coop\">generationkwh@somenergia.</a>",

--- a/src/i18n/locale-gl.json
+++ b/src/i18n/locale-gl.json
@@ -687,6 +687,7 @@
     "CAU_INVALID_INSTALLATION": "O código CAU debe rematar con A e tres números",
     "CAU_INVALID_LENGTH": "O código CAU debe ter 26 caracteres",
     "CAU_INVALID_CONTROL_DIGIT": "O código CAU non é válido",
+    "CAU_INVALID_CUPS": "O código CAU non coincide cos 20 primeiros caracteres do CUPS",
     "GENERATION_CONTRIBUTION_NO_MEMBER_VAT": "Insire o teu DNI ou NIF",
     "GENERATION_BUTTON_ADD_ASSIGNMENT": "Asignar un novo contrato",
     "GENERATION_ADD_ASSIGNMENTS_INFO_MSG": "Ten en conta que só podes engadir contratos dos que es titular. Se queres engadir un contrato doutra persoa, escríbenos un correo electrónico a <a href=\"mailto:generationkwh@somenergia.coop\">generationkwh@somenergia.</a>",


### PR DESCRIPTION
## Description

When a person has an individual installation, CAU must start with the first 20 digits of the CUPS. This PR changes the order between the CAU field and the collective type selector and adds this validation.

## Changes

As all the CAU validations are done in CAU field, we decided to add there the validation instead of in Yup.
- Ask first if the installation is individual or collective
- Validate that the CAU starts with the 20 first of the CUPS when the installation is individual.

## Checklist

Justify any unchecked point:

- [ ] Changed code is covered by tests --> Tests are not passing (we will fix it as Bugbuster's task)
- [ ] Relevant changes are explained in the "Unreleased" section of the `CHANGES.md` file --> Not relevant changes
- [ ] That section includes "Upgrade notes" with any config, dependency or deploy tweek needed on development and server setups --> N/A
- [ ] Changes on the setup process (development, testing, production) have been updated in the proper documentation --> N/A


