### PR TITLE
Fix: CAU validation fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 ## Unreleased
 
 - Removed google tracking
+- Fix: CAU helper text when untouched was required error and not the help.
+- Fix: Infinite loop on remote CAU validation
+- Fix: Recovered pretty format on CAU, IBAN and Cadaster
+- Fix: Recovered the Checking... message and spiner in CAU, IBAN, Cadaster
 
 ## 2.3.15 2024-10-22
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+- Removed google tracking
+
 ## 2.3.15 2024-10-22
 
 - Fix: Was forcing cau-cups matching in the wrong case (collective)

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "react": "^18.3.1",
     "react-beautiful-dnd": "^13.1.1",
     "react-dom": "^18.3.1",
-    "react-ga": "^3.3.0",
     "react-hotkeys": "^2.0.0",
     "react-i18next": "^14.0.0",
     "react-router-dom": "^6.2.2",

--- a/src/components/ApiValidatedField.jsx
+++ b/src/components/ApiValidatedField.jsx
@@ -45,9 +45,10 @@ export function ApiValidatedField({
     if (!remoteCheck) {
       onChange(result)
     }
-    onChange({ ...result, valid: false, error: t('API_VALIDATED_FIELD_CHECKING')  })
+    const compactValue = result.value
+    onChange({ value: compactValue, valid: false, error: t('API_VALIDATED_FIELD_CHECKING')  })
     setIsLoading(true)
-    remoteCheck(result.value).then((result) => {
+    remoteCheck(compactValue).then((result) => {
       setIsLoading(false)
       onChange(result)
     })
@@ -59,8 +60,9 @@ export function ApiValidatedField({
     checkValue(formattedValue)
   }
 
-  if (value !== formerValue) {
-    checkValue(value)
+  const prettyValue = input? inputFilter(value) : value
+  if (prettyValue !== formerValue) {
+    checkValue(prettyValue)
   }
 
   return (
@@ -73,7 +75,7 @@ export function ApiValidatedField({
         fullWidth
         required={required}
         autoFocus={autoFocus}
-        value={inputFilter?inputFilter(value):value}
+        value={prettyValue}
         onChange={handleChange}
         onBlur={onBlur}
         error={!!error}

--- a/src/components/ApiValidatedField.jsx
+++ b/src/components/ApiValidatedField.jsx
@@ -47,7 +47,7 @@ export function ApiValidatedField({
     }
     onChange({ ...result, valid: false, error: t('API_VALIDATED_FIELD_CHECKING')  })
     setIsLoading(true)
-    remoteCheck(valueToCheck).then((result) => {
+    remoteCheck(result.value).then((result) => {
       setIsLoading(false)
       onChange(result)
     })

--- a/src/components/ApiValidatedField.jsx
+++ b/src/components/ApiValidatedField.jsx
@@ -33,15 +33,19 @@ export function ApiValidatedField({
 
   function checkValue(valueToCheck) {
     setFormerValue(valueToCheck)
-    if (valueToCheck == '') {
+    if (!valueToCheck) {
       onChange({ valueToCheck, valid: true, error: undefined })
       return
     }
     const result = localCheck(valueToCheck)
-    const needsRemote = result.valid
-
-    onChange({ ...result, valid: false })
-    if (!needsRemote) return
+    if (!result.valid) {
+      onChange(result)
+      return
+    }
+    if (!remoteCheck) {
+      onChange(result)
+    }
+    onChange({ ...result, valid: false, error: t('API_VALIDATED_FIELD_CHECKING')  })
     setIsLoading(true)
     remoteCheck(valueToCheck).then((result) => {
       setIsLoading(false)

--- a/src/components/ApiValidatedField.jsx
+++ b/src/components/ApiValidatedField.jsx
@@ -76,7 +76,7 @@ export function ApiValidatedField({
         value={inputFilter?inputFilter(value):value}
         onChange={handleChange}
         onBlur={onBlur}
-        error={error}
+        error={!!error}
         helperText={
           isLoading
             ? t('API_VALIDATED_FIELD_CHECKING')

--- a/src/components/ApiValidatedField.jsx
+++ b/src/components/ApiValidatedField.jsx
@@ -73,7 +73,7 @@ export function ApiValidatedField({
         fullWidth
         required={required}
         autoFocus={autoFocus}
-        value={value}
+        value={inputFilter?inputFilter(value):value}
         onChange={handleChange}
         onBlur={onBlur}
         error={error}

--- a/src/components/ApiValidatedField.jsx
+++ b/src/components/ApiValidatedField.jsx
@@ -7,6 +7,22 @@ import CheckOutlinedIcon from '@mui/icons-material/CheckOutlined'
 
 import { useTranslation } from 'react-i18next'
 
+/*
+TODO: known bugs
+
+- Abort remote checks on edit.
+If you edit the field while an external validation is in progress,
+when the external validation ends it reverts the edit.
+We should apply query abortion on every edit similar to the
+ones proposed [here](https://dev.to/bil/using-abortcontroller-with-react-hooks-and-typescript-to-cancel-window-fetch-requests-1md4).
+
+- Restore selection (cursor).
+Editing in the middle moves the cursor to the end, making editing a pain.
+When an edition in the middle changes the spaces position within the content,
+React's automatic cursor restoration thinks it is a full programmatic
+value replacement and moves the cursor at the end.
+*/
+
 
 export function ApiValidatedField({
   name,

--- a/src/components/ApiValidatedField.jsx
+++ b/src/components/ApiValidatedField.jsx
@@ -76,7 +76,7 @@ export function ApiValidatedField({
     checkValue(formattedValue)
   }
 
-  const prettyValue = input? inputFilter(value) : value
+  const prettyValue = inputFilter? inputFilter(value) : value
   if (prettyValue !== formerValue) {
     checkValue(prettyValue)
   }

--- a/src/components/ApiValidatedField.jsx
+++ b/src/components/ApiValidatedField.jsx
@@ -90,11 +90,11 @@ export function ApiValidatedField({
               <LeadingIcon />
             </InputAdornment>
           ),
-          endAdornment: isLoading || isLoading ? (
+          endAdornment: isLoading || !error ? (
             <InputAdornment position="end">
               {isLoading ? (
                 <CircularProgress size={24} />
-              ) : error ? (
+              ) : value && !error ? (
                 <CheckOutlinedIcon color="primary" />
               ) : null}
             </InputAdornment>

--- a/src/components/CAUField.jsx
+++ b/src/components/CAUField.jsx
@@ -3,27 +3,10 @@ import { checkCups } from '../services/api'
 import SolarPowerIcon from '@mui/icons-material/WbSunny'
 import { useTranslation } from 'react-i18next'
 import ApiValidatedField from './ApiValidatedField'
-import { checkCAUWhileTyping } from '../services/utils'
+import { checkCAUWhileTyping, prettyCAU } from '../services/utils'
 
 export function CAUField(props) {
   const { t } = useTranslation()
-  function inputFilter(value) {
-    if (!value) return value
-    value = value.replace(/[^0-9A-Za-z]/g, '') // TODO: Do not cut chars after not matching one
-    value = value.slice(0, 26)
-    value = value.toUpperCase()
-    value = [
-      value.slice(0, 2), // ES
-      value.slice(2, 6), // Supplier
-      value.slice(6, 10), // Supply point
-      value.slice(10, 14), // Supply point
-      value.slice(14, 18), // Supply point
-      value.slice(18, 20), // Control
-      value.slice(20, 22), // Border point
-      value.slice(22, 26), // CAU
-    ].join(' ').trim()
-    return value
-  }
 
   function localCheck(value) {
     return checkCAUWhileTyping(value, t, props.cupsToMatch)
@@ -51,7 +34,7 @@ export function CAUField(props) {
     <ApiValidatedField
       {...props}
       leadingIcon={SolarPowerIcon}
-      inputFilter={inputFilter}
+      inputFilter={prettyCAU}
       localCheck={localCheck}
       remoteCheck={remoteCheck}
     />

--- a/src/components/MemberIdentifierFields.jsx
+++ b/src/components/MemberIdentifierFields.jsx
@@ -141,7 +141,7 @@ const MemberIdentifierFields = (props) => {
               <Typography sx={{
                 fontWeight: 500,
                 color: 'primary.main'
-              }} component='body1'>
+              }} variant='helpertext'>
                 {t('SOCIA_TROBADA')}
               </Typography>
             ))

--- a/src/containers/Contract.jsx
+++ b/src/containers/Contract.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useContext } from 'react'
-import ReactGA from 'react-ga'
 import Plausible from 'plausible-tracker'
 
 import { useTranslation } from 'react-i18next'
@@ -807,9 +806,6 @@ const Contract = (props) => {
         window.location.hostname +
         '/es/contratacion-realizada/'
     })
-
-    ReactGA.initialize(GA_TRACKING_ID)
-    ReactGA.pageview('/es/contratacion-realizada/')
   }
 
   const handlePost = async (values) => {

--- a/src/containers/Contract/SelfConsumptionDetails.jsx
+++ b/src/containers/Contract/SelfConsumptionDetails.jsx
@@ -151,10 +151,10 @@ const SelfConsumptionDetails = (props) => {
             onChange={handleChangeCAU}
             onBlur={handleBlur}
             error={
-              values?.self_consumption?.cau && !!errors?.self_consumption?.cau
+              touched?.self_consumption?.cau && !!errors?.self_consumption?.cau
             }
             helperText={
-              errors?.self_consumption?.cau || (
+              (!!values?.self_consumption?.cau && errors?.self_consumption?.cau) || (
                 <a
                   href={t('SELFCONSUMPTION_CAU_HELP_URL')}
                   target="_blank"

--- a/src/containers/Contract/SelfConsumptionDetails.jsx
+++ b/src/containers/Contract/SelfConsumptionDetails.jsx
@@ -151,6 +151,7 @@ const SelfConsumptionDetails = (props) => {
             onChange={handleChangeCAU}
             onBlur={handleBlur}
             error={
+              // Do not show errors if not touched
               touched?.self_consumption?.cau && !!errors?.self_consumption?.cau
             }
             helperText={

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -592,3 +592,22 @@ export const checkCAUWhileTyping = (value, t, matchingCups) => {
   return {value, valid: true}
 }
 
+export const prettyCAU = (value) => {
+  if (!value) return value
+  value = value.replace(/[^0-9A-Za-z]/g, '') // TODO: Do not cut chars after not matching one
+  value = value.slice(0, 26)
+  value = value.toUpperCase()
+  value = [
+    value.slice(0, 2), // ES
+    value.slice(2, 6), // Supplier
+    value.slice(6, 10), // Supply point
+    value.slice(10, 14), // Supply point
+    value.slice(14, 18), // Supply point
+    value.slice(18, 20), // Control
+    value.slice(20, 22), // Border point
+    value.slice(22, 26) // CAU
+  ]
+    .join(' ')
+    .trim()
+  return value
+}


### PR DESCRIPTION
## Description

Fix some regressions on CAU validation and ApiValidatedFields (IBAN, CadastralRef) introduced in my last PR, and reverting some old features (pretty printing, initial message, progress indicators) that had been disabled because similar cases, now reviewd and fixed.

## Changes

- Fix: Avoided validation infinite loop on ApiValidatedFields because i remote validated the pretty version of the value
- Fix: Initial CAU validated message "where to find the CAU code" was substituted by  "CAU required" messsage. Now the later is shown only once the field is visited.
- Fix: "Checking..." message on checking restored
- Fix: Reverted splitted (pretty) display for ApiValidatedFields (CAU, IBAN, Cadastral) for an easier the review by the user.

## Checklist

Justify any unchecked point:

- [ ] Changed code is covered by tests.
- [ ] Relevant changes are explained in the "Unreleased" section of the `CHANGES.md` file.
- [ ] That section includes "Upgrade notes" with any config, dependency or deploy tweek needed on development and server setups.
- [ ] Changes on the setup process (development, testing, production) have been updated in the proper documentation

## Observations

- It looks like that pretty format caused infinite loops in the past when combined with Formik validation. It was disabled but pretty format was still living inside the widget and i struggled with that.
- The solution to enable it again and avoiding loops was to define two realms, inside the widget pretty format is the one. But compact format is the one received from and sent to the outside world.
- Pretty view for CUPS is still disabled because is not a ApiValidatedField yet. A future fix could be applying the fixes also to CUPS. Current change affects to IBAN, CAU and Cadastral Reference.
- Known old glitches (present in old versions and not fixed):
    - If you edit the field while an external validation is in progress, when the external validation ends it reverts the edit. We should apply query abortion here on every edit similar to the ones proposed [here](https://dev.to/bil/using-abortcontroller-with-react-hooks-and-typescript-to-cancel-window-fetch-requests-1md4).
    - Editing in the middle of the value moves the cursor to the end when the pretty string changes too much, making editing in the middle a pain. 
    - Current recheck when the individual/collective field changes, still does an extra render validation cycle. Because it is done in an useEffect it takes an extra render to have it updated. I couldn't find a better/simpler solution thought. Being an inter field interaction, maybe the check should be moved up, but this isn't an direct change, for the (not so) quick fix that it was needed here.

## Please, review

- CAU validation, but also IBAN and Cadastral Reference
     - Messages are consistent as you edit the fields
- I guess that the changes i reverted might have other motivations than that. It works for me, but, please review if old bugs have not reverted.

## How to check the new features

You could deploy locally or use testing since i deployed it in there.

## Deploy notes


