### PR TITLE
✨ new entry points in wp for new member

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -187,24 +187,19 @@ const App = (props) => {
                   }
                 />
 
-                <Route path="/new-member" element={<Member {...props} />} />
-
-                <Route
-                  path="/:language/fes-te-n-soci-a/"
-                  element={<Member {...props} />}
-                />
-                <Route
-                  path="/:language/hazte-socio-a/"
-                  element={<Member {...props} />}
-                />
-                <Route
-                  path="/:language/izan-zaitez-bazkide/"
-                  element={<Member {...props} />}
-                />
-                <Route
-                  path="/:language/faite-socio-a/"
-                  element={<Member {...props} />}
-                />
+                {[
+                  "/new-member",
+                  "/:language/associat/",
+                  "/:language/asociate/", // es, gl
+                  "/:language/bazkidetu/",
+                  // Deprecated entrypoints: remove after transition to "associat" as the official pages
+                  "/:language/fes-te-n-soci-a/",
+                  "/:language/hazte-socio-a/",
+                  "/:language/izan-zaitez-bazkide/",
+                  "/:language/faite-socio-a/",
+                ].map((path)=> (
+                  <Route path={path} key={path} element={<Member {...props} />} />
+                ))}
 
                 <Route
                   path="/d1-detail"


### PR DESCRIPTION
## Description

Add new entry points for new new-member pages in web since they have been renamed.

## Changes

- Added the new url where the new-member form will be.

## Checklist

Justify any unchecked point:

- [ ] Changed code is covered by tests.
- [ ] Relevant changes are explained in the "Unreleased" section of the `CHANGES.md` file.
- [ ] That section includes "Upgrade notes" with any config, dependency or deploy tweek needed on development and server setups.
- [ ] Changes on the setup process (development, testing, production) have been updated in the proper documentation

## Observations

- Old urls have been kept for the transition period
- Instead of repeating the whole block i am doing a map for the urls responding with the same form.
- I tried to create a new component MultiRoute and it looked even better but Router compained that it should be a Route element.

## Please, review

- The use of a map is ok and could be extended to other urls sharing components.

## How to check the new features

- Accessing to the new urls in the website

## Deploy notes

- already deployed on testing website

