### PR TITLE
🐛 personaldata message only for holderchange

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+- Fix: show a PersonalData message only for Holderchange
+
 ## 2.4.2 2024-12-04
 
 - Gurb: validation pages for non-members
@@ -7,6 +11,7 @@
 - Fix tpv asynchronous submit
 
 ## 2.4.1 2024-11-11
+
 - Added message for autonomous (Modify Contract form)
 - Added feature flag: noticeAutonomous
 

--- a/src/containers/HolderChange.jsx
+++ b/src/containers/HolderChange.jsx
@@ -297,6 +297,7 @@ function HolderChange(props) {
             url={url}
             {...props}
             isMemberMandatoryForHolderchange={isMemberMandatoryForHolderchange}
+            form='holderchange'
           />
         )}
         {activeStep === 6 && <VoluntaryCent {...props} />}

--- a/src/containers/HolderChange/PersonalData.jsx
+++ b/src/containers/HolderChange/PersonalData.jsx
@@ -39,7 +39,8 @@ function PersonalData(props) {
     skipPrivacyPolicy = false,
     title = false,
     entity = 'holder',
-    isMemberMandatoryForHolderchange = false
+    isMemberMandatoryForHolderchange = false,
+    form = undefined
   } = props
   const [openLegal, setOpenLegal] = useState(false)
   const trialPeriod =
@@ -128,7 +129,7 @@ function PersonalData(props) {
         <StepHeader
           title={
             entity === 'holder'
-              ? !isMemberMandatoryForHolderchange && trialPeriod
+              ? form === 'holderchange' && !isMemberMandatoryForHolderchange && trialPeriod
                 ? t('HOLDER_PERSONAL_DATA_TRIAL_PERIOD')
                 : t('HOLDER_PERSONAL_DATA')
               : t('MEMBER_PERSONAL_DATA')


### PR DESCRIPTION
## Description

`PersonalData` is a generic screen, but there is a message that has to appear only for Holderchange form.

## Changes

- Added a `form` param to `PersonalData` component (undefined by default).
- Check if form is 'holderchange' to determine if we have to show a message.
- Pass the form param for holderchange.

## Checklist

Justify any unchecked point:

- [ ] Changed code is covered by tests: N/A?
- [x] Relevant changes are explained in the "Unreleased" section of the `CHANGES.md` file.
- [ ] That section includes "Upgrade notes" with any config, dependency or deploy tweek needed on development and server setups: N/A
- [ ] Changes on the setup process (development, testing, production) have been updated in the proper documentation: N/A

## Observations

## Please, review

- That the message appears when it has to.


