### PR TITLE
Fix tests gurb flow

### DIFF
--- a/.env.pre
+++ b/.env.pre
@@ -1,5 +1,5 @@
 # web somenergia test
 
 BASE_URL=/wp-content/plugins/react-wordpress/webforms/build/
-VITE_WEBFORMS_API_URL=https://testapi-nonpersistence.somenergia.coop
+VITE_WEBFORMS_API_URL=https://testapi.somenergia.coop
 VITE_MATOMO_URL="https://matomo.somenergia.coop/js/container_i9uB2r3V.js"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+- checkMember: get the response from data and not from the state field
+- checkMember: moved from data to check
+
 ## 2.6.4 2025-02-18
 
 - New contract gurb form

--- a/cypress/fixtures/gurb.json
+++ b/cypress/fixtures/gurb.json
@@ -11,5 +11,5 @@
     "repeat_email": "kaizokuounioreesnaru@onepiece.freedom",
     "phone1": "560000000"
   },
-  "randomIban": "ES7712341234161234567890"
+  "randomIban": "ES4600763612815691358826"
 }

--- a/cypress/integration/contract/contract.spec.js
+++ b/cypress/integration/contract/contract.spec.js
@@ -230,7 +230,7 @@ describe('Contract', () => {
     let memberNumber = this.data.member.number
     let memberVat = this.data.member.badVat
 
-    cy.intercept('GET', '/data/soci/**').as('checkMember')
+    cy.intercept('GET', '/check/soci/**').as('checkMember')
 
     cy.get('#memberNumber')
       .clear()

--- a/cypress/integration/generationkwhContribution/generationContribution.spec.js
+++ b/cypress/integration/generationkwhContribution/generationContribution.spec.js
@@ -224,11 +224,11 @@ describe('Generation Form', () => {
         statusCode: 400,
       }).as('checkVat')
 
-      cy.intercept('GET', '/data/soci/**',
+      cy.intercept('GET', '/check/soci/**',
         {
           statusCode: 200,
           body: {
-            data: { soci: {} },
+            data: true,
             state: true
           }
         }).as('checkMember')

--- a/cypress/integration/gurb/gurb.spec.js
+++ b/cypress/integration/gurb/gurb.spec.js
@@ -54,7 +54,7 @@ describe('Contract', () => {
 
       cy.memberQuestion('member-on')
 
-      cy.identifyMember({ vat: this.personaldata.memberVat, number: this.personaldata.memberNumber })
+      cy.identifyMemberGURB({ vat: this.personaldata.memberVat, number: this.personaldata.memberNumber })
 
       cy.identifyHolderGURB(this.personaldata.vat)  // Test whats happend if VAT is same as newMember VAT
 
@@ -82,7 +82,7 @@ describe('Contract', () => {
 
       cy.memberQuestion('apadrinating')
 
-      cy.identifyMember({ vat: this.personaldata.memberVat, number: this.personaldata.memberNumber })
+      cy.identifyMemberGURB({ vat: this.personaldata.memberVat, number: this.personaldata.memberNumber })
 
       cy.identifyHolderGURB(this.personaldata.vat)  // Test whats happend if VAT is same as newMember VAT
 

--- a/cypress/support/contractCommands.js
+++ b/cypress/support/contractCommands.js
@@ -1,7 +1,7 @@
 Cypress.Commands.add('identifyMember', (memberNumber, memberVat) => {
 
   cy.intercept('GET', '/check/vat/*').as('checkVat')
-  cy.intercept('GET', '/data/soci/**').as('checkMember')
+  cy.intercept('GET', '/check/soci/**').as('checkMember')
 
   cy.get('#memberNumber')
     .clear()
@@ -24,11 +24,11 @@ Cypress.Commands.add('identifyMember', (memberNumber, memberVat) => {
 
 Cypress.Commands.add('generationkwhIdentifyMember', (memberNumber, memberVat, canJoin) => {
 
-  cy.intercept('GET', '/data/soci/**',
+  cy.intercept('GET', '/check/soci/**',
     {
       statusCode: 200,
       body: {
-        data: { soci: {} },
+        data: true,
         state: true
       }
     }).as('checkMember')

--- a/cypress/support/gurbCommands.js
+++ b/cypress/support/gurbCommands.js
@@ -57,7 +57,7 @@ Cypress.Commands.add('memberQuestion', (optionValue = 'member-on') => {
   cy.get('[data-cy=next]').click()
 })
 
-Cypress.Commands.add('identifyMember', ({vat, number}) => {
+Cypress.Commands.add('identifyMemberGURB', ({vat, number}) => {
 
   cy.get('[data-cy="vat"]').type(vat)
   cy.get('[data-cy="code"]').type(number)

--- a/src/components/MemberIdentifierFields.jsx
+++ b/src/components/MemberIdentifierFields.jsx
@@ -49,11 +49,11 @@ const MemberIdentifierFields = (props) => {
       }
 
       try {
-        const member = await checkMember(
+        const response = await checkMember(
           values.member.number,
           values.member.vat
         )
-        if (member?.state === true) {
+        if (response?.data === true) {
           setError(false)
           setFieldValue('member.checked', true)
         } else {

--- a/src/containers/Generation/GenerationForm/GenerationMemberIdFields.jsx
+++ b/src/containers/Generation/GenerationForm/GenerationMemberIdFields.jsx
@@ -71,11 +71,11 @@ const GenerationMemberIdFields = (props) => {
       }
 
       try {
-        const member = await checkMember(
+        const response = await checkMember(
           values.member.partner_number,
           values.member.vat
         )
-        if (member?.state === true) {
+        if (response?.data === true) {
           setError(false)
         } else {
           setError(true)

--- a/src/containers/Gurb/pages/NewMember/ApadrinatingDetails.jsx
+++ b/src/containers/Gurb/pages/NewMember/ApadrinatingDetails.jsx
@@ -25,7 +25,7 @@ const ApadrinatingDetails = (props) => {
     let status = undefined
     await checkMember(values.member.number, values.member.nif)
       .then((response) => {
-        status = response?.state
+        status = response?.data
       })
       .catch(() => {
         status = false

--- a/src/containers/Gurb/pages/NewMember/MemberDetails.jsx
+++ b/src/containers/Gurb/pages/NewMember/MemberDetails.jsx
@@ -26,7 +26,7 @@ const MemberDetails = (props) => {
     setLoading(true)
     await checkMember(values.member.number, values.member.nif)
       .then((response) => {
-        status = response?.state
+        status = response?.data
       })
       .catch(() => {
         status = false

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -230,7 +230,7 @@ export const checkMember = async (number, vat) => {
 
   return axios({
     method: 'GET',
-    url: `${WEBFORMS_API_URL}/data/soci/${number}/${vat}`,
+    url: `${WEBFORMS_API_URL}/check/soci/${number}/${vat}`,
     cancelToken: cancelTokenMember.token
   }).then((response) => {
     return response?.data


### PR DESCRIPTION
## Description

Hello :wave: This is the first refactor of GURB endpoints.

In this case, the lucky one is the well known `_dades_soci` (aka endpoint maldito). Its path was `/data/soci/${number}/${vat}` and its version was `@apiv1`.

## Changes

- get the response from `data` and not from the `state` field
- from datas to checks
- changed checkMember result as response instead of member

## Checklist

Justify any unchecked point:

- [x] Changed code is covered by tests.
- [x] Relevant changes are explained in the "Unreleased" section of the `CHANGES.md` file.
- [ ] That section includes "Upgrade notes" with any config, dependency or deploy tweek needed on development and server setups: N/A
- [ ] Changes on the setup process (development, testing, production) have been updated in the proper documentation: N/A

~:warning:  **Hem d'adaptar alguns tests de cypress!!!** :warning:~ --> Fet!

