### PR TITLE
Fix translations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## unreleased
+
+- HELPER_NUMBER_ADDRESS changed by empty string
+- Add key ERROR_FIELD_LENGTH
+- Change ERROR_FIELD_LENGTH by INVALID_REF_CADASTRAL_LENGTH in cadastral yup validation
+
 ## 5.0.11 2025-07-29
 
 - Change http by https in docs and translations

--- a/src/containers/NewContractMember/newContractMemberSupplyPointDataValidations.js
+++ b/src/containers/NewContractMember/newContractMemberSupplyPointDataValidations.js
@@ -1,7 +1,7 @@
 import * as Yup from 'yup'
 
 const newContractMemberSupplyPointDataValidations = Yup.object().shape({
-  cadastral_reference: Yup.string().length(23, 'ERROR_FIELD_LENGTH'),
+  cadastral_reference: Yup.string().length(23, 'INVALID_REF_CADASTRAL_LENGTH'),
   cadastral_reference_valid: Yup.bool()
   .required('CADASTRAL_REFERENCE_ERROR')
   .oneOf([true], 'CADASTRAL_REFERENCE_ERROR'),

--- a/src/i18n/locale-ca.json
+++ b/src/i18n/locale-ca.json
@@ -1018,7 +1018,7 @@
     "GENERIC_CONDITIONS_URL": "GENERIC_CONDITIONS_URL",
     "GURB_CHECK_SPECIFIC_CONDITIONS_URL": "GURB_CHECK_SPECIFIC_CONDITIONS_URL",
     "POSTAL_CODE": "Codi postal",
-    "HELPER_NUMBER_ADDRESS": "Si vius en una casa sense número introdueix el número 0 en aquest camp",
+    "HELPER_NUMBER_ADDRESS": "",
     "SAVE_CHANGES": "Guardar canvis",
     "GURB_CHECK_TARIFF_PAYMENNT_ACCEPTED": "L'acceptació d'aquestes condicions particulars obliga al pagament del consum al preu que resulti de l'aplicació de la tarifa contractada.",
     "CADASTRAL_REFERENCE_HELPER": "Si no saps on trobar la referència cadastral, pots buscar-la al registre o anar al",

--- a/src/i18n/locale-es.json
+++ b/src/i18n/locale-es.json
@@ -895,7 +895,7 @@
     "NEW_MEMBER_SUBMIT_LOADING": "Estamos dando de alta a la nueva persona socia",
     "NEW_CONTRACT_SUBMIT_LOADING": "Estamos gestionando la petición",
     "POSTAL_CODE": "Código postal",
-    "HELPER_NUMBER_ADDRESS": "Si vives en una casa sin número introduce el número 0 en este campo",
+    "HELPER_NUMBER_ADDRESS": "",
     "SAVE_CHANGES": "Guardar cambios",
     "NEW_MEMBER_CONTRACT_SUCCESS_TITLE": "¡Ya eres de Som Energia!",
     "NEW_MEMBER_CONTRACT_SUCCESS_DESC": "Recibirás un correo con tu número de persona socia y con toda la información sobre tu nuevo contrato.",
@@ -916,5 +916,6 @@
     "ERROR_FIELD_TOO_LONG": "Campo demasiado largo",
     "ERROR_FIELD_TOO_SHORT": "Campo demasiado corto",
     "GURB_VOLUNTARY_DONATION_HELPER": "Siempre podrás activar o desactivar esta opción dentro el área de clientes",
-    "NEW_HOLDER_SAME_TITLE": "Sí, la persona titular y la socia son la misma"
+    "NEW_HOLDER_SAME_TITLE": "Sí, la persona titular y la socia son la misma",
+    "ERROR_FIELD_LENGTH": "Logintud del campo incorrecta"
 }

--- a/src/i18n/locale-eu.json
+++ b/src/i18n/locale-eu.json
@@ -894,7 +894,7 @@
     "SELECT_OPTION": "-- Hautatu aukera bat --",
     "LIGHT_OFF_URL": "https://eu.support.somenergia.coop/article/462-une-honetan-ez-dago-argirik-nola-eskatu-hornidura-puntu-berri-bat?utm_source=linkidiomes&utm_medium=cda&utm_campaign=euskara",
     "POSTAL_CODE": "Posta-kodea",
-    "HELPER_NUMBER_ADDRESS": "Zure etxeak ez badu zenbakirik, eremu honetan jarri 0 zenbakia",
+    "HELPER_NUMBER_ADDRESS": "",
     "SAVE_CHANGES": "Gorde aldaketak",
     "NEW_MEMBER_CONTRACT_SUCCESS_TITLE": "Som Energiaren bazkidea zara jada!",
     "NEW_MEMBER_CONTRACT_SUCCESS_DESC": "Mezu bat jasoko duzu zure bazkide-zenbakiarekin eta kontratu berriari buruzko informazio guztiarekin.",

--- a/src/i18n/locale-gl.json
+++ b/src/i18n/locale-gl.json
@@ -885,7 +885,7 @@
     "SELECT_OPTION": "-- Selecciona unha opción --",
     "LIGHT_OFF_URL": "https://gl.support.somenergia.coop/article/385-non-teno-luz-actualmente-podo-solicitar-un-novo-punto-de-consumo?utm_source=linkidiomes&utm_medium=cda&utm_campaign=galego",
     "POSTAL_CODE": "Código postal",
-    "HELPER_NUMBER_ADDRESS": "Se vives nunha casa sen número introduce o número 0 neste campo",
+    "HELPER_NUMBER_ADDRESS": "",
     "SAVE_CHANGES": "Gardar cambios",
     "NEW_MEMBER_CONTRACT_SUCCESS_TITLE": "Xa es de Som Energia!",
     "NEW_MEMBER_CONTRACT_SUCCESS_DESC": "Recibirás un correo co teu número de persoa socia e con toda a información sobre o teu novo contrato.",


### PR DESCRIPTION
## Description
Fix some translations keys

## Changes

- HELPER_NUMBER_ADDRESS changed by empty string (Comer asked to keep the key for possible translation in future)
- Add key ERROR_FIELD_LENGTH
- Change ERROR_FIELD_LENGTH by INVALID_REF_CADASTRAL_LENGTH in cadastral yup validation

## Checklist

Justify any unchecked point:

- [X] Changed code is covered by tests.
- [ ] Relevant changes are explained in the "Unreleased" section of the `CHANGES.md` file.
- [ ] That section includes "Upgrade notes" with any config, dependency or deploy tweek needed on development and server setups.
- [ ] Changes on the setup process (development, testing, production) have been updated in the proper documentation
