### PR TITLE
🐛 fix tipography default color to inherit color

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## unreleased
+
+- REF: Add inherit colors for typography
+
 ## 7.1.1 2026-04-02
 
 - Formik broken validations

--- a/src/themes/webforms.js
+++ b/src/themes/webforms.js
@@ -3,7 +3,6 @@ import { createTheme, responsiveFontSizes } from '@mui/material/styles'
 export default function WebFormsTheme() {
   const theme = createTheme({
     palette: {
-      //contrastThreshold: 2, // From webforms-ui
       contrastThreshold: 4.5, // Recommended by WCAG 2.1 Rule 1.4.3
       primary: {
         main: '#0B2E34',
@@ -13,7 +12,7 @@ export default function WebFormsTheme() {
         mainOrange: '#ff632b',
         lightOrange: '#ffcdb5',
         alt: '#afb5e8',
-        contrastText: '#fff'
+        contrastText: '#fff',
       },
       secondary: {
         main: '#C4C4C4',
@@ -29,7 +28,7 @@ export default function WebFormsTheme() {
         third: '#F0F3EC',
         button: '#C5F47C',
         hoverButton: '#B6E471',
-        alertBox: '#ffcdb580', // 50% opacidad primary.mainOrange
+        alertBox: '#ffcdb580', // 50% primary.mainOrange opacity
         customDialog: '#0C4C2780'
       },
       error: {
@@ -116,8 +115,8 @@ export default function WebFormsTheme() {
     components: {
       MuiTypography: {
         defaultProps: {
+          color: 'inherit',
           fontFamily: 'Outfit',
-          color: '#0B2E34',
           variantMapping: {
             display1: 'h1',
             display2: 'h2',
@@ -137,7 +136,7 @@ export default function WebFormsTheme() {
             'button.md': 'button',
             'button.sm': 'button'
           }
-        }
+        },
       },
       MuiCssBaseline: {
         styleOverrides: {
@@ -148,16 +147,11 @@ export default function WebFormsTheme() {
             color: '#0c4c27',
           },
           '#root': {
-            background: 'transparent',
-            color: '#1E1E1E',
             fontSize: '16px',
             fontFamily: 'Outfit',
           },
           '#root b': {
             fontWeight: 500,
-          },
-          '.MuiDatePickerToolbar-title': {
-            color: 'white !important', // FIXME: workaround
           },
         },
       },


### PR DESCRIPTION
## Description

Remove manual toolbar color overrides for SomDatePicker as they are no longer needed.

## Changes

- change theme's tipography default color to inherit color

## Testing

- [x] The branch has same master's branch colors
- [x] SomDatePicker toolbar show text with contrastColor

## Checklist

Justify any unchecked point:

- [x] Changed code is covered by tests.
- [ ] Relevant changes are explained in the "Unreleased" section of the `CHANGES.md` file.
- [ ] That section includes "Upgrade notes" with any config, dependency or deploy tweek needed on development and server setups.
- [ ] Changes on the setup process (development, testing, production) have been updated in the proper documentation
