### PR TITLE
🐛 process when light-off

### DIFF
--- a/src/containers/NewContractMember/pages/NewContractMemberSummary.jsx
+++ b/src/containers/NewContractMember/pages/NewContractMemberSummary.jsx
@@ -252,8 +252,8 @@ const NewContractMemberSummary = (props) => {
       }
 
   const process = contractProcess(
-    values?.has_light == 'light-on',
-    values?.previous_holder == 'previous-holder-yes'
+    values?.has_light === 'light-off',
+    values?.previous_holder === 'previous-holder-yes'
   )
   const processType = {
     icon: <InvoiceIcon />,

--- a/src/services/newNormalize.js
+++ b/src/services/newNormalize.js
@@ -56,8 +56,8 @@ export const normalizeSelfconsumption = (selfconsumption) => {
   return data
 }
 
-export const contractProcess = (has_light, same_holder) => {
-  if (!has_light) {
+export const contractProcess = (light_off, same_holder) => {
+  if (light_off) {
     return 'A3'
   } else if (same_holder) {
     return 'C1'
@@ -81,8 +81,8 @@ export const newNormalizeContract = (data, gurbCode) => {
     powers.push(data.contract.power[`power${i}`])
   }
   const process = contractProcess(
-        data.has_light == 'light-on',
-        data.previous_holder == 'previous-holder-yes'
+        data.has_light === 'light-off',
+        data.previous_holder === 'previous-holder-yes'
       )
 
   const finalContract = {

--- a/src/services/newNormalize.test.js
+++ b/src/services/newNormalize.test.js
@@ -91,6 +91,12 @@ describe('Check Contract new Form (normalize function)', () => {
     ).toStrictEqual(newContractCases.A3_indexed.normalizedData)
   })
 
+  test('Normalize Contract data (A3 periods has_light=light-off)', () => {
+    expect(
+      newNormalizeContract(newContractCases.A3_periods_has_light.entryValues)
+    ).toStrictEqual(newContractCases.A3_periods_has_light.normalizedData)
+  })
+
   test('Normalize Contract data (C2 3.0TD)', () => {
     expect(
       newNormalizeContract(newContractCases.C2_30TD.entryValues)

--- a/src/services/utilsMockData/forms/newContract/index.js
+++ b/src/services/utilsMockData/forms/newContract/index.js
@@ -32,6 +32,17 @@ const contract_info_a3_indexed = {
   phase: "230"
 }
 
+const contract_info_a3_periods = {
+  cnae: '9820',
+  cups: random_cups,
+  cups_address: address.normalizedData,
+  is_indexed: false,
+  powers: ['2100', '2500'],
+  process: 'A3',
+  tariff: '2.0TD',
+  phase: "230"
+}
+
 const contract_info_c2_30TD = {
   cnae: '9820',
   cups: random_cups,
@@ -248,6 +259,61 @@ const A3_indexed = {
   },
   normalizedData: {
     contract_info: contract_info_a3_indexed,
+    donation: true,
+    general_contract_terms_accepted: true,
+    iban: random_iban,
+    linked_member: 'already_member',
+    linked_member_info: {
+      code: random_number,
+      vat: random_nif
+    },
+    member_payment_type: 'remesa',
+    privacy_conditions: true,
+    sepa_accepted: true,
+    statutes_accepted: true
+  }
+}
+
+const A3_periods_has_light = {
+  entryValues: {
+    cups: random_cups,
+    has_member: 'member-on',
+    has_light: 'light-off',
+    previous_holder: 'previous-holder-yes',
+    voluntary_donation: true,
+    cadastral_reference_valid: true,
+    supply_point: supply_point.without_attachments.entryValues,
+    supply_point_address: address.entryValues,
+    address: address.empty,
+    member: {
+      number: random_number,
+      nif: random_nif,
+      link_member: true
+    },
+    new_member: {
+      ...client.empty,
+      ...iban_values,
+      payment_method: 'iban'
+    },
+    contract: {
+      tariff_mode: 'atr',
+      power_type: 'power-lower-15kw',
+      power: {
+        power1: '2.1',
+        power2: '2.5'
+      },
+      phase: 'mono'
+    },
+    has_selfconsumption: 'selfconsumption-off',
+    self_consumption: selfconsumption.empty,
+    privacy_policy_accepted: true,
+    generic_conditions_accepted: true,
+    statutes_accepted: true,
+    comercial_info_accepted: false,
+    is_client: false
+  },
+  normalizedData: {
+    contract_info: contract_info_a3_periods,
     donation: true,
     general_contract_terms_accepted: true,
     iban: random_iban,
@@ -498,6 +564,7 @@ const newContractCases = {
   // Contract cases
   // C1_20TD: base case for member cases
   A3_indexed: A3_indexed,
+  A3_periods_has_light: A3_periods_has_light,
   C2_30TD: C2_30TD,
   selfconsumption: withSelfconsumption,
   cadastraslReference: cadastralReference,


### PR DESCRIPTION
## Description

Contract process is set to A3 is not corretly determined, because exact value of light-off is not asked.

## Changes

- A3 is only set when has_light is equal to light-off

## Checklist

Justify any unchecked point:

- [X] Changed code is covered by tests.
- [X] Relevant changes are explained in the "Unreleased" section of the `CHANGES.md` file.
- [ ] That section includes "Upgrade notes" with any config, dependency or deploy tweek needed on development and server setups.
- [ ] Changes on the setup process (development, testing, production) have been updated in the proper documentation

## Observations

## Please, review

- List of things authors emphasize to review

## How to check the new features

## Deploy notes


