### PR TITLE
New matomo tagmanager trackers

### DIFF
--- a/src/containers/NewContractMember/NewContractMember.jsx
+++ b/src/containers/NewContractMember/NewContractMember.jsx
@@ -88,7 +88,7 @@ const NewContractMemberForm = (props) => {
 
   const { loading } = useContext(LoadingContext)
   const { summaryField, setSummaryField } = useContext(SummaryContext)
-  const { trackEvent } = useContext(MatomoContext)
+  const { trackEvent, pushTag } = useContext(MatomoContext)
   const [sending, setSending] = useState(false)
 
   const [activeStep, setActiveStep] = useState(initStep ? parseInt(initStep) : 0)
@@ -333,6 +333,10 @@ const NewContractMemberForm = (props) => {
       })
     }
     triggerEvent('FormularioCompletado', { status: 'ok' })
+    pushTag({
+      event: 'lead',
+      componentName: 'FormulariContractacio'
+    })
   }
 
   const handlePost = async (values) => {
@@ -448,6 +452,13 @@ const NewContractMemberForm = (props) => {
       setActiveStep(summaryField)
     }
   }, [summaryField])
+
+  useEffect(() => {
+    pushTag({
+      event: 'begin_checkout',
+      componentName: 'FormulariContractacio'
+    })
+  }, [])
 
   useEffect(() => {
     trackEvent({

--- a/src/trackers/matomo/MatomoProvider.jsx
+++ b/src/trackers/matomo/MatomoProvider.jsx
@@ -1,21 +1,27 @@
-import React, { createContext, useState, useCallback, useMemo } from 'react'
+import { createContext, useState, useCallback, useMemo } from 'react'
 import MatomoTracker from './MatomoTracker'
 
 export const MatomoContext = createContext({
-  trackEvent: () => { }
+  trackEvent: () => {},
+  pushTag: () => {}
 })
 
 export const MatomoProvider = ({ children }) => {
-
   const [MatomoInstance] = useState(new MatomoTracker())
 
   const trackEvent = useCallback(
     (params) => MatomoInstance?.trackEvent(params),
     [MatomoInstance]
   )
+
+  const pushTag = useCallback(
+    (params) => MatomoInstance?.pushTag(params),
+    [MatomoInstance]
+  )
+
   const contextValue = useMemo(
-    () => ({trackEvent}),
-    [trackEvent]
+    () => ({ trackEvent, pushTag }),
+    [trackEvent, pushTag]
   )
   return (
     <MatomoContext.Provider value={contextValue}>

--- a/src/trackers/matomo/MatomoTracker.js
+++ b/src/trackers/matomo/MatomoTracker.js
@@ -37,6 +37,7 @@ class MatomoTracker {
   }
 
   pushTag({ event, componentName }) {
+    window._mtm = window._mtm || []
     window._mtm.push({
       event,
       componentName

--- a/src/trackers/matomo/MatomoTracker.js
+++ b/src/trackers/matomo/MatomoTracker.js
@@ -1,39 +1,62 @@
 class MatomoTracker {
   constructor() {
-    this.initialize();
+    this.initialize()
   }
 
   initialize() {
-
     if (document.getElementById('matomo_tracker') === null) {
-      var _paq = window._paq = window._paq || [];
+      var _paq = (window._paq = window._paq || [])
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-      _paq.push(['trackPageView']);
-      _paq.push(['enableLinkTracking']);
-      (function () {
-        var u = import.meta.env.VITE_MATOMO_URL;
-        _paq.push(['setTrackerUrl', u + 'matomo.php']);
-        _paq.push(['setSiteId', import.meta.env.VITE_MATOMO_SITE_ID]);
-        var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
-        g.async = true; g.id = 'matomo_tracker'; g.src = u + 'matomo.js'; s.parentNode.insertBefore(g, s);
-      })();
+      _paq.push(['trackPageView'])
+      _paq.push(['enableLinkTracking'])
+      ;(function () {
+        var u = import.meta.env.VITE_MATOMO_URL
+        _paq.push(['setTrackerUrl', u + 'matomo.php'])
+        _paq.push(['setSiteId', import.meta.env.VITE_MATOMO_SITE_ID])
+        var d = document,
+          g = d.createElement('script'),
+          s = d.getElementsByTagName('script')[0]
+        g.async = true
+        g.id = 'matomo_tracker'
+        g.src = u + 'matomo.js'
+        s.parentNode.insertBefore(g, s)
+      })()
+
+      // Matomo Tag Manager
+      const _mtm = (window._mtm = window._mtm || [])
+      _mtm.push({ 'mtm.startTime': new Date().getTime(), event: 'mtm.Start' })
+      ;(function () {
+        var d = document,
+          g = d.createElement('script'),
+          s = d.getElementsByTagName('script')[0]
+        g.async = true
+        g.src = 'https://matomo.somenergia.coop/js/container_Jck5ZJOE.js'
+        s.parentNode.insertBefore(g, s)
+      })()
     }
+  }
+
+  pushTag({ event, componentName }) {
+    window._mtm.push({
+      event,
+      componentName
+    })
   }
 
   trackEvent({ category, action, name, value }) {
     if (category && action) {
-      this.pushInstruction('trackEvent', category, action, name, value);
+      this.pushInstruction('trackEvent', category, action, name, value)
     } else {
-      throw new Error(`Error: category and action are required.`);
+      throw new Error(`Error: category and action are required.`)
     }
   }
 
   pushInstruction(matomoFunctionName, category, action, name, value) {
     if (typeof window !== 'undefined') {
-      window._paq.push([matomoFunctionName, category, action, name, value]);
+      window._paq.push([matomoFunctionName, category, action, name, value])
     }
 
-    return this;
+    return this
   }
 }
 


### PR DESCRIPTION
## Description

Add Matomo Tag Manager container and 2 triggers: begin_checkout and lead

## Changes

- NewContractMember fire begin_checkout
- MatomoTracker includes the code to initiate TagManager container

## Checklist

Justify any unchecked point:

- [x] Changed code is covered by tests.
- [ ] Relevant changes are explained in the "Unreleased" section of the `CHANGES.md` file.
- [ ] That section includes "Upgrade notes" with any config, dependency or deploy tweek needed on development and server setups.
- [ ] Changes on the setup process (development, testing, production) have been updated in the proper documentation

## How to check the new features

Disable browser's extension can block the cookies or trakers.

- [ ] Open a contract form
- [ ] Add the query param at url's end `?mtmPreviewMode=Jck5ZJOE` example:  http://localhost:3000/ca/formulario-contratacion-indexada?mtmPreviewMode=Jck5ZJOE
- [ ] View 'begin_checkout' fired
- [ ] When complete form View 'lead' fired