### PR TITLE
🐛 setSending when tpv

### DIFF
--- a/src/containers/NewMember/NewMember.jsx
+++ b/src/containers/NewMember/NewMember.jsx
@@ -158,17 +158,19 @@ const NewMemberForm = () => {
             setUrl(response.data.endpoint)
           } else {
             setCompleted(true)
+            setSending(false)
           }
         } else {
           setCompleted(true)
+          setSending(false)
           setError(true)
         }
       })
       .catch(() => {
         setCompleted(true)
+        setSending(false)
         setError(true)
       })
-    setSending(false)
   }
 
   const getStep = (props) => {

--- a/src/containers/NewMember/NewMember.jsx
+++ b/src/containers/NewMember/NewMember.jsx
@@ -140,36 +140,38 @@ const NewMemberForm = () => {
   }
 
   const handlePost = async (values) => {
-    setSending(true)
     trackEvent({
       category: 'Send',
       action: 'sendNewMemberClick',
       name: 'send-new-member'
     })
 
+    setSending(true)
+
+    const finishSubmission = ({ hasError }) => {
+      setCompleted(true)
+      setError(hasError)
+      setSending(false)
+    }
     const data = newNormalizeMember(values)
     await member(data)
       .then((response) => {
-        if (response?.state === true) {
+        if (response?.state !== true) {
+          finishSubmission({ hasError: true })
+          return
+        }
+
+        trackSuccess()
+        if (response?.data?.endpoint) {
           setError(false)
-          trackSuccess()
-          if (response?.data?.endpoint) {
-            setData(response?.data)
-            setUrl(response.data.endpoint)
-          } else {
-            setCompleted(true)
-            setSending(false)
-          }
+          setData(response.data)
+          setUrl(response.data.endpoint)
         } else {
-          setCompleted(true)
-          setSending(false)
-          setError(true)
+          finishSubmission({ hasError: false })
         }
       })
       .catch(() => {
-        setCompleted(true)
-        setSending(false)
-        setError(true)
+        finishSubmission({ hasError: true })
       })
   }
 

--- a/src/containers/NewMember/NewMember.jsx
+++ b/src/containers/NewMember/NewMember.jsx
@@ -154,7 +154,7 @@ const NewMemberForm = () => {
       setSending(false)
     }
     const data = newNormalizeMember(values)
-    await member(data)
+    member(data)
       .then((response) => {
         if (response?.state !== true) {
           finishSubmission({ hasError: true })


### PR DESCRIPTION
## Description

In new member form, when tpv option is selected, and once we arrived to the summary page, the last part of the flux was:

`summary > loading > summary > Redsys`

The proper flux: `summary > loading  > Redsys`

In this PR we fixed the loading after summary page. 

## Changes

- set sending to false only if we are not paying with TPV

## Checklist

Justify any unchecked point:

- [ ] Changed code is covered by tests.
- [ ] Relevant changes are explained in the "Unreleased" section of the `CHANGES.md` file.
- [ ] That section includes "Upgrade notes" with any config, dependency or deploy tweek needed on development and server setups.
- [ ] Changes on the setup process (development, testing, production) have been updated in the proper documentation

## Observations

## Please, review

- That the flux after summary works properly:  `summary > loading  > Redsys > success page`

## How to check the new features

You can test NewMember form locally or go to [vercel](https://webforms-ui-git-fixloadingbeforetpv-somenergia.vercel.app/ca/cooperativa/formulario-asociarse) 



